### PR TITLE
Add support for multiple e-card targets.

### DIFF
--- a/packages/scripts/dist/ecard-to-target.js
+++ b/packages/scripts/dist/ecard-to-target.js
@@ -23,8 +23,10 @@ export class EcardToTarget {
     shouldRun() {
         return (window.hasOwnProperty("EngridEcardToTarget") &&
             typeof window.EngridEcardToTarget === "object" &&
-            window.EngridEcardToTarget.hasOwnProperty("targetName") &&
-            window.EngridEcardToTarget.hasOwnProperty("targetEmail"));
+            ((window.EngridEcardToTarget.hasOwnProperty("targetName") &&
+                window.EngridEcardToTarget.hasOwnProperty("targetEmail")) ||
+                (window.EngridEcardToTarget.hasOwnProperty("targets") &&
+                    window.EngridEcardToTarget.targets.length > 0)));
     }
     setTarget() {
         const targetNameField = document.querySelector(".en__ecardrecipients__name input");
@@ -34,10 +36,29 @@ export class EcardToTarget {
             this.logger.error("Could not add recipient. Required elements not found.");
             return;
         }
-        targetNameField.value = this.options.targetName;
-        targetEmailField.value = this.options.targetEmail;
-        addRecipientButton === null || addRecipientButton === void 0 ? void 0 : addRecipientButton.click();
-        this.logger.log("Added recipient", this.options.targetName, this.options.targetEmail);
+        let targets = this.options.targets;
+        if (this.options.targetName && this.options.targetEmail) {
+            targets.push({
+                targetName: this.options.targetName,
+                targetEmail: this.options.targetEmail,
+            });
+        }
+        // Remove duplicates from targets array
+        targets = targets.filter((target, index, self) => index ===
+            self.findIndex((t) => t.targetName === target.targetName &&
+                t.targetEmail === target.targetEmail));
+        targets.forEach((target) => {
+            const targetName = target.targetName;
+            const targetEmail = target.targetEmail;
+            if (!targetName || !targetEmail) {
+                this.logger.error("Could not add recipient. Target name or email is empty.");
+                return;
+            }
+            targetNameField.value = targetName;
+            targetEmailField.value = targetEmail;
+            addRecipientButton === null || addRecipientButton === void 0 ? void 0 : addRecipientButton.click();
+            this.logger.log("Added recipient", targetName, targetEmail);
+        });
     }
     hideElements() {
         const messageBlock = document.querySelector(".en__ecardmessage");

--- a/packages/scripts/dist/interfaces/ecard-to-target-options.d.ts
+++ b/packages/scripts/dist/interfaces/ecard-to-target-options.d.ts
@@ -5,5 +5,9 @@ export interface EcardToTargetOptions {
     hideTarget: boolean;
     hideMessage: boolean;
     addSupporterNameToMessage: boolean;
+    targets: {
+        targetName: string;
+        targetEmail: string;
+    }[];
 }
 export declare const EcardToTargetOptionsDefaults: EcardToTargetOptions;

--- a/packages/scripts/dist/interfaces/ecard-to-target-options.js
+++ b/packages/scripts/dist/interfaces/ecard-to-target-options.js
@@ -5,4 +5,5 @@ export const EcardToTargetOptionsDefaults = {
     hideTarget: true,
     hideMessage: true,
     addSupporterNameToMessage: false,
+    targets: [],
 };

--- a/packages/scripts/src/interfaces/ecard-to-target-options.ts
+++ b/packages/scripts/src/interfaces/ecard-to-target-options.ts
@@ -5,6 +5,10 @@ export interface EcardToTargetOptions {
   hideTarget: boolean;
   hideMessage: boolean;
   addSupporterNameToMessage: boolean;
+  targets: {
+    targetName: string;
+    targetEmail: string;
+  }[];
 }
 
 export const EcardToTargetOptionsDefaults: EcardToTargetOptions = {
@@ -14,4 +18,5 @@ export const EcardToTargetOptionsDefaults: EcardToTargetOptions = {
   hideTarget: true,
   hideMessage: true,
   addSupporterNameToMessage: false,
+  targets: [],
 };


### PR DESCRIPTION
Introduced a `targets` array to handle multiple recipients while maintaining backward compatibility for single recipient fields. The implementation includes duplicate filtering and validation to ensure correct and efficient recipient processing.

It can be tested on this page https://act.ran.org/page/82522/action/1?mode=DEMO which uses an asset branch for RAN that is build with this ENgrid branch.