### PR TITLE
adjust disableSubmit to allow overriding the original text if it isn'…

### DIFF
--- a/packages/scripts/dist/engrid.js
+++ b/packages/scripts/dist/engrid.js
@@ -335,8 +335,8 @@ export class ENGrid {
         if (!submit)
             return false;
         let submitButtonProcessingHTML = `<span class='loader-wrapper'><span class='loader loader-quart'></span><span class='submit-button-text-wrapper'>${label}</span></span>`;
-        if ("originalText" in submit.dataset && submit.disabled) {
-            // If the original text is already set and the button is disabled, that means this function was called before
+        if (submit.innerHTML.includes("loader-wrapper")) {
+            // If we are already processing, don't override the originalText again
             return false;
         }
         submit.dataset.originalText = submit.innerHTML;

--- a/packages/scripts/src/engrid.ts
+++ b/packages/scripts/src/engrid.ts
@@ -400,8 +400,8 @@ export abstract class ENGrid {
     ) as HTMLButtonElement;
     if (!submit) return false;
     let submitButtonProcessingHTML = `<span class='loader-wrapper'><span class='loader loader-quart'></span><span class='submit-button-text-wrapper'>${label}</span></span>`;
-    if ("originalText" in submit.dataset && submit.disabled) {
-      // If the original text is already set and the button is disabled, that means this function was called before
+    if (submit.innerHTML.includes("loader-wrapper")) {
+      // If we are already processing, don't override the originalText again
       return false;
     }
     submit.dataset.originalText = submit.innerHTML;


### PR DESCRIPTION
…t the loader text

This PR addresses the issue I reported at https://app.productive.io/2650-4site-interactive-studios-inc/task/9689186?taskActivityId=178862204

I've tested it on Safari too this time, but I think my original code was wrong too, sorry!