### PR TITLE
Update NB to add a timeout option

### DIFF
--- a/packages/scripts/dist/interfaces/options.d.ts
+++ b/packages/scripts/dist/interfaces/options.d.ts
@@ -22,6 +22,7 @@ export interface Options {
     NeverBounceDateField?: string | null;
     NeverBounceDateFormat?: string;
     NeverBounceStatusField?: string | null;
+    NeverBounceTimeout?: number | null;
     FreshAddress?: false | {
         dateField?: string;
         dateFieldFormat?: string;

--- a/packages/scripts/dist/interfaces/options.js
+++ b/packages/scripts/dist/interfaces/options.js
@@ -21,6 +21,7 @@ export const OptionsDefaults = {
     NeverBounceDateField: null,
     NeverBounceStatusField: null,
     NeverBounceDateFormat: "MM/DD/YYYY",
+    NeverBounceTimeout: 10000,
     FreshAddress: false,
     ProgressBar: false,
     AutoYear: false,

--- a/packages/scripts/dist/neverbounce.d.ts
+++ b/packages/scripts/dist/neverbounce.d.ts
@@ -13,6 +13,8 @@ export declare class NeverBounce {
     private shouldRun;
     private nbLoaded;
     private bypassEmails;
+    private neverBounceTimeout;
+    private neverBounceTimeoutFunc;
     constructor(apiKey: string, dateField: string | null, statusField: string | null, dateFormat: string | undefined);
     private init;
     private clearStatus;
@@ -22,4 +24,9 @@ export declare class NeverBounce {
     private wrap;
     private isBypassEmail;
     private validate;
+    /**
+     * Clears the backup timeout function if it exists.
+     * @private
+     */
+    private clearTimeout;
 }

--- a/packages/scripts/src/interfaces/options.ts
+++ b/packages/scripts/src/interfaces/options.ts
@@ -22,6 +22,7 @@ export interface Options {
   NeverBounceDateField?: string | null;
   NeverBounceDateFormat?: string;
   NeverBounceStatusField?: string | null;
+  NeverBounceTimeout?: number | null;
   FreshAddress?:
     | false
     | {
@@ -199,6 +200,7 @@ export const OptionsDefaults: Options = {
   NeverBounceDateField: null,
   NeverBounceStatusField: null,
   NeverBounceDateFormat: "MM/DD/YYYY",
+  NeverBounceTimeout: 10000,
   FreshAddress: false,
   ProgressBar: false,
   AutoYear: false,


### PR DESCRIPTION
Adds a timeout option to NeverBounce so that in the case of a server error with NB, form submission can still happen.

NB has a "timeout" option for its widget in which it will return an "unknown" status if its processing goes beyond that timeout.

I added a new ENgrid option NeverBounceTimeout default 10000 milliseconds. The NB widget timeout is set to a second less than whatever value is given to this parameter. If NB works properly, then it should always timeout and return an "unknown" status before our timeout triggers, as long as their servers are working properly.

If our timeout is hit, we set a status of "unknown", re-enable the submit button and remove NB validation from the email field.

It can be tested on this page: https://support.npca.org/page/87929/donate/1?mode=DEMO you can reduce the parameter exposed in the code block NeverBounceTimeout: 5000 but it cant be lower than 2000 (2 seconds in milliseconds)