### PR TITLE
Use inmem check box to help determine embedded ecard visibility (resubmission)

### DIFF
--- a/packages/scripts/dist/embedded-ecard.js
+++ b/packages/scripts/dist/embedded-ecard.js
@@ -94,8 +94,15 @@ export class EmbeddedEcard {
         return iframe;
     }
     addEventListeners() {
+        var _a;
+        const inMemoriamCheckbox = document.getElementById("en__field_transaction_inmem");
         const sendEcardCheckbox = document.getElementById("en__field_embedded-ecard");
-        this.toggleEcardForm(sendEcardCheckbox.checked);
+        this.toggleEcardForm(((_a = inMemoriamCheckbox === null || inMemoriamCheckbox === void 0 ? void 0 : inMemoriamCheckbox.checked) !== null && _a !== void 0 ? _a : true) && sendEcardCheckbox.checked);
+        inMemoriamCheckbox === null || inMemoriamCheckbox === void 0 ? void 0 : inMemoriamCheckbox.addEventListener("change", (e) => {
+            const checkbox = e.target;
+            const _sendEcardCheckbox = document.getElementById("en__field_embedded-ecard");
+            this.toggleEcardForm(checkbox.checked && _sendEcardCheckbox.checked);
+        });
         sendEcardCheckbox === null || sendEcardCheckbox === void 0 ? void 0 : sendEcardCheckbox.addEventListener("change", (e) => {
             const checkbox = e.target;
             this.toggleEcardForm(checkbox.checked);

--- a/packages/scripts/dist/embedded-ecard.js
+++ b/packages/scripts/dist/embedded-ecard.js
@@ -95,14 +95,19 @@ export class EmbeddedEcard {
     }
     addEventListeners() {
         var _a;
-        const inMemoriamCheckbox = document.getElementById("en__field_transaction_inmem");
         const sendEcardCheckbox = document.getElementById("en__field_embedded-ecard");
-        this.toggleEcardForm(((_a = inMemoriamCheckbox === null || inMemoriamCheckbox === void 0 ? void 0 : inMemoriamCheckbox.checked) !== null && _a !== void 0 ? _a : true) && sendEcardCheckbox.checked);
-        inMemoriamCheckbox === null || inMemoriamCheckbox === void 0 ? void 0 : inMemoriamCheckbox.addEventListener("change", (e) => {
-            const checkbox = e.target;
-            const _sendEcardCheckbox = document.getElementById("en__field_embedded-ecard");
-            this.toggleEcardForm(checkbox.checked && _sendEcardCheckbox.checked);
-        });
+        if (this.options.requireInMemCheckbox) {
+            const inMemoriamCheckbox = document.getElementById("en__field_transaction_inmem");
+            inMemoriamCheckbox === null || inMemoriamCheckbox === void 0 ? void 0 : inMemoriamCheckbox.addEventListener("change", (e) => {
+                const checkbox = e.target;
+                const _sendEcardCheckbox = document.getElementById("en__field_embedded-ecard");
+                this.toggleEcardForm(checkbox.checked && _sendEcardCheckbox.checked);
+            });
+            this.toggleEcardForm(((_a = inMemoriamCheckbox === null || inMemoriamCheckbox === void 0 ? void 0 : inMemoriamCheckbox.checked) !== null && _a !== void 0 ? _a : true) && sendEcardCheckbox.checked);
+        }
+        else {
+            this.toggleEcardForm(sendEcardCheckbox.checked);
+        }
         sendEcardCheckbox === null || sendEcardCheckbox === void 0 ? void 0 : sendEcardCheckbox.addEventListener("change", (e) => {
             const checkbox = e.target;
             this.toggleEcardForm(checkbox.checked);

--- a/packages/scripts/dist/interfaces/embedded-ecard-options.d.ts
+++ b/packages/scripts/dist/interfaces/embedded-ecard-options.d.ts
@@ -4,5 +4,6 @@ export interface EmbeddedEcardOptions {
     checkboxText: string;
     anchor: string;
     placement: string;
+    requireInMemCheckbox: boolean;
 }
 export declare const EmbeddedEcardOptionsDefaults: EmbeddedEcardOptions;

--- a/packages/scripts/dist/interfaces/embedded-ecard-options.js
+++ b/packages/scripts/dist/interfaces/embedded-ecard-options.js
@@ -4,4 +4,5 @@ export const EmbeddedEcardOptionsDefaults = {
     checkboxText: "Yes, I would like to send an ecard to announce my gift.",
     anchor: ".en__field--donationAmt",
     placement: "afterend",
+    requireInMemCheckbox: false,
 };

--- a/packages/scripts/src/embedded-ecard.ts
+++ b/packages/scripts/src/embedded-ecard.ts
@@ -141,20 +141,26 @@ export class EmbeddedEcard {
   }
 
   private addEventListeners() {
-    const inMemoriamCheckbox = document.getElementById(
-      "en__field_transaction_inmem"
-    ) as HTMLInputElement;
     const sendEcardCheckbox = document.getElementById(
       "en__field_embedded-ecard"
     ) as HTMLInputElement;
 
-    this.toggleEcardForm((inMemoriamCheckbox?.checked ?? true) && sendEcardCheckbox.checked);
+    if(this.options.requireInMemCheckbox) {
+      const inMemoriamCheckbox = document.getElementById(
+        "en__field_transaction_inmem"
+      ) as HTMLInputElement;
 
-    inMemoriamCheckbox?.addEventListener("change", (e) => {
-      const checkbox = e.target as HTMLInputElement;
-      const _sendEcardCheckbox = document.getElementById("en__field_embedded-ecard") as HTMLInputElement;
-      this.toggleEcardForm(checkbox.checked && _sendEcardCheckbox.checked);
-    });
+      inMemoriamCheckbox?.addEventListener("change", (e) => {
+        const checkbox = e.target as HTMLInputElement;
+        const _sendEcardCheckbox = document.getElementById("en__field_embedded-ecard") as HTMLInputElement;
+        this.toggleEcardForm(checkbox.checked && _sendEcardCheckbox.checked);
+      });
+      
+      this.toggleEcardForm((inMemoriamCheckbox?.checked ?? true) && sendEcardCheckbox.checked);
+    } else {
+      this.toggleEcardForm(sendEcardCheckbox.checked);
+    }
+
     sendEcardCheckbox?.addEventListener("change", (e) => {
       const checkbox = e.target as HTMLInputElement;
       this.toggleEcardForm(checkbox.checked);

--- a/packages/scripts/src/embedded-ecard.ts
+++ b/packages/scripts/src/embedded-ecard.ts
@@ -141,12 +141,20 @@ export class EmbeddedEcard {
   }
 
   private addEventListeners() {
+    const inMemoriamCheckbox = document.getElementById(
+      "en__field_transaction_inmem"
+    ) as HTMLInputElement;
     const sendEcardCheckbox = document.getElementById(
       "en__field_embedded-ecard"
     ) as HTMLInputElement;
 
-    this.toggleEcardForm(sendEcardCheckbox.checked);
+    this.toggleEcardForm((inMemoriamCheckbox?.checked ?? true) && sendEcardCheckbox.checked);
 
+    inMemoriamCheckbox?.addEventListener("change", (e) => {
+      const checkbox = e.target as HTMLInputElement;
+      const _sendEcardCheckbox = document.getElementById("en__field_embedded-ecard") as HTMLInputElement;
+      this.toggleEcardForm(checkbox.checked && _sendEcardCheckbox.checked);
+    });
     sendEcardCheckbox?.addEventListener("change", (e) => {
       const checkbox = e.target as HTMLInputElement;
       this.toggleEcardForm(checkbox.checked);

--- a/packages/scripts/src/interfaces/embedded-ecard-options.ts
+++ b/packages/scripts/src/interfaces/embedded-ecard-options.ts
@@ -4,6 +4,7 @@ export interface EmbeddedEcardOptions {
   checkboxText: string;
   anchor: string;
   placement: string;
+  requireInMemCheckbox: boolean;
 }
 
 export const EmbeddedEcardOptionsDefaults: EmbeddedEcardOptions = {
@@ -12,4 +13,5 @@ export const EmbeddedEcardOptionsDefaults: EmbeddedEcardOptions = {
   checkboxText: "Yes, I would like to send an ecard to announce my gift.",
   anchor: ".en__field--donationAmt",
   placement: "afterend",
+  requireInMemCheckbox: false,
 };


### PR DESCRIPTION
Functionality can be tested at https://donate.spcai.org/page/179187/donate/1?assets=dev-nick

This feature adds the `requireInMemCheckbox` option in the `EngridEmbeddedEcard` configuration.
It will toggle the visibility of the ecard embed based on the both the state of the radio buttons (`supporter.NOT_TAGGED_11`) and the `transaction.inmem` checkbox.

Behavior table is as follows:



| requireInMemCheckbox | In Mem Checked | E-Card Radio Checked | Visible?          |
|----------------------|----------------|----------------------|-------------------|
| Y                    | N              | N                    | N                 |
| Y                    | Y              | N                    | N                 |
| Y                    | N              | Y                    | N                 |
| Y                    | Y              | Y                    | Y                 |
| N                    | N              | N                    | N                 |
| N                    | Y              | N                    | N                 |
| N                    | N              | Y                    | Y - Problem Case! |
| N                    | Y              | Y                    | Y                 |