### PR TITLE
VGS - Add support for valid card brands

### DIFF
--- a/packages/scripts/dist/interfaces/options.d.ts
+++ b/packages/scripts/dist/interfaces/options.d.ts
@@ -109,6 +109,9 @@ export interface Options {
             };
             ariaLabel?: string;
             placeholder?: string;
+            validCardBrands?: {
+                type: string;
+            }[] | null;
         };
         "transaction.ccvv"?: {
             showCardIcon?: boolean | object;

--- a/packages/scripts/dist/vgs.js
+++ b/packages/scripts/dist/vgs.js
@@ -141,6 +141,7 @@ export class VGS {
                 // Autocomplete is not customizable
                 autoComplete: "cc-number",
                 validations: ["required", "validCardNumber"],
+                validCardBrands: null
             },
             "transaction.ccvv": {
                 showCardIcon: false,
@@ -158,6 +159,12 @@ export class VGS {
                 css: styles,
             },
         };
+        // Override the validCardBrands if set in the theme options, as this should not be deep merged.
+        if (options &&
+            options["transaction.ccnumber"] &&
+            options["transaction.ccnumber"].validCardBrands) {
+            defaultOptions["transaction.ccnumber"].validCardBrands = options["transaction.ccnumber"].validCardBrands;
+        }
         // Deep merge the default options with the options set in the theme
         this.options = ENGrid.deepMerge(defaultOptions, options);
         this.logger.log("Options", this.options);

--- a/packages/scripts/src/interfaces/options.ts
+++ b/packages/scripts/src/interfaces/options.ts
@@ -112,6 +112,9 @@ export interface Options {
           };
           ariaLabel?: string;
           placeholder?: string;
+          validCardBrands?: {
+            type: string;
+          }[] | null;
         };
         "transaction.ccvv"?: {
           showCardIcon?: boolean | object;

--- a/packages/scripts/src/vgs.ts
+++ b/packages/scripts/src/vgs.ts
@@ -113,6 +113,7 @@ export class VGS {
         // Autocomplete is not customizable
         autoComplete: "cc-number",
         validations: ["required", "validCardNumber"],
+        validCardBrands: <{ type: string }[]|null>null
       },
       "transaction.ccvv": {
         showCardIcon: false,
@@ -130,6 +131,14 @@ export class VGS {
         css: styles,
       },
     };
+    // Override the validCardBrands if set in the theme options, as this should not be deep merged.
+    if (
+      options &&
+      options["transaction.ccnumber"] &&
+      options["transaction.ccnumber"].validCardBrands
+    ) {
+      defaultOptions["transaction.ccnumber"].validCardBrands = options["transaction.ccnumber"].validCardBrands;
+    }
     // Deep merge the default options with the options set in the theme
     this.options = ENGrid.deepMerge(defaultOptions, options);
     this.logger.log("Options", this.options);


### PR DESCRIPTION
From: https://app.productive.io/2650-4site-interactive-studios-inc/tasks/15072056

This implements support in the VGS module to allow a client theme to specify supported card brands. By default, all brands are supported (with a value of null, rather than an exhaustive list). Because of this, I have made a special exception to the deepMerge, as deep merging with the defaultOptions having value of null or undefined would result in a failed merge, defaultOptions having all available card types would result in all available card types working regardless of client theme specification, and defaultOptions having a value of an empty array would require all client themes be updated to specify what card types are needed. This was my best approach to maximizing compatibility.

Test page: https://protect.worldwildlife.org/page/69817/donate/1?assets=deny-diner-jcb&debug=log

Testing steps:
Attempting any card only requires inputting the value into the credit card field, no other fields are needed to be filled to test validation.
- Attempt a test visa card `4242424242424242`, no error should occur for the credit card field when hitting submit.
- Attempt a test Diner's Club card `3056930009020004`, a "Credit Card number is invalid" error should occur
- Attempt a test union pay card `6200000000000005`, no error should occur
- Attempt a test JCB card `3566002020360505`, a "Credit Card number is invalid" error should occur

Further testing could include pulling the `deny-diner-jcb` branch, and this `vgs-card-brands` branch together locally and modifying the options in `index.ts:91` such as
- Removing the options entirely and testing that all brands work
- Removing visa and testing that a visa card now has an invalid error
- Adding jcb and testing that jcb no longer has an invalid error

Just remember to update the url such that `assets=local`

The list of available brand codes is here: https://docs.verygoodsecurity.com/vault/developer-tools/vgs-collect/js/customization#card-brand-identification