### PR TITLE
TidyContact: Allow defining what EN page types it can run on

### DIFF
--- a/packages/scripts/dist/interfaces/options.d.ts
+++ b/packages/scripts/dist/interfaces/options.d.ts
@@ -51,6 +51,7 @@ export interface Options {
     };
     TidyContact?: false | {
         cid?: string;
+        page_types?: ("DONATION" | "ECARD" | "SURVEY" | "EMAILTOTARGET" | "ADVOCACY" | "SUBSCRIBEFORM" | "EVENT" | "SUPPORTERHUB" | "UNSUBSCRIBE" | "TWEETPAGE" | "UNKNOWN")[];
         record_field?: string;
         date_field?: string;
         status_field?: string;

--- a/packages/scripts/dist/tidycontact.d.ts
+++ b/packages/scripts/dist/tidycontact.d.ts
@@ -11,6 +11,7 @@ export declare class TidyContact {
     private countries_dropdown;
     private country_ip;
     constructor();
+    private shouldRun;
     private loadOptions;
     private createFields;
     private createPhoneFields;

--- a/packages/scripts/dist/tidycontact.js
+++ b/packages/scripts/dist/tidycontact.js
@@ -268,6 +268,10 @@ export class TidyContact {
         this.options = ENGrid.getOption("TidyContact");
         if (this.options === false || !((_a = this.options) === null || _a === void 0 ? void 0 : _a.cid))
             return;
+        if (!this.shouldRun()) {
+            this.logger.log("TidyContact is disabled on this page type");
+            return;
+        }
         this.loadOptions();
         if (!this.hasAddressFields() && !this.phoneEnabled()) {
             this.logger.log("No address fields found");
@@ -297,6 +301,14 @@ export class TidyContact {
                 this.setDefaultPhoneCountry();
             }
         }
+    }
+    shouldRun() {
+        if (this.options &&
+            this.options.page_types &&
+            this.options.page_types.length > 0) {
+            return this.options.page_types.includes(ENGrid.getPageType());
+        }
+        return true;
     }
     loadOptions() {
         var _a, _b, _c, _d;

--- a/packages/scripts/src/interfaces/options.ts
+++ b/packages/scripts/src/interfaces/options.ts
@@ -57,6 +57,7 @@ export interface Options {
     | false
     | {
         cid?: string; // Client ID
+        page_types?: ("DONATION" | "ECARD" | "SURVEY" | "EMAILTOTARGET" | "ADVOCACY" | "SUBSCRIBEFORM" | "EVENT" | "SUPPORTERHUB" | "UNSUBSCRIBE" | "TWEETPAGE" | "UNKNOWN")[]; // Page Types to enable TidyContact on, if left blank will run on all page types
         record_field?: string; // TidyContact Record
         date_field?: string; // TidyContact Date
         status_field?: string; // TidyContact Status

--- a/packages/scripts/src/tidycontact.ts
+++ b/packages/scripts/src/tidycontact.ts
@@ -269,6 +269,10 @@ export class TidyContact {
   constructor() {
     this.options = ENGrid.getOption("TidyContact") as Options["TidyContact"];
     if (this.options === false || !this.options?.cid) return;
+    if (!this.shouldRun()) {
+      this.logger.log("TidyContact is disabled on this page type");
+      return;
+    }
     this.loadOptions();
     if (!this.hasAddressFields() && !this.phoneEnabled()) {
       this.logger.log("No address fields found");
@@ -308,6 +312,16 @@ export class TidyContact {
         this.setDefaultPhoneCountry();
       }
     }
+  }
+  private shouldRun(): boolean {
+    if (
+      this.options &&
+      this.options.page_types &&
+      this.options.page_types.length > 0
+    ) {
+      return this.options.page_types.includes(ENGrid.getPageType());
+    }
+    return true;
   }
   private loadOptions() {
     if (this.options) {


### PR DESCRIPTION
This update adds an additional option field `page_types` that allow client themes to specify what EN page types TidyContact should run on. When a page type is not on this allowlist a "TidyContact is disabled on this page type" is printed via the logger.

Expected behaviors:
| Config Setting               | Page Type     | Runs? |
| ---------------------------- | ------------- | ----- |
| []                           | \*            | YES   |
| undefined, unset, etc. (Backwards-Compatability)       | \*            | YES   |
| ["DONATION"]                 | DONATION      | YES   |
| ["DONATION"]                 | SUBSCRIBEFORM | NO    |
| ["DONATION","SUBSCRIBEFORM"] | DONATION      | YES   |
| ["DONATION","SUBSCRIBEFORM"] | SUBSCRIBEFORM | YES   |

Test pages, uploaded from a branch with the config set to `["DONATION"]`:
DONATION Page - https://act.ran.org/page/90802/donate/1?assets=tc-pagetypes-test&debug=log (TC should run)
SUBSCRIBEFORM Page - https://act.ran.org/page/55579/subscribe/1?assets=tc-pagetypes-test&debug=log (TC should not run)

Associated task: https://app.productive.io/2650-4site-interactive-studios-inc/tasks/15508244