### PR TITLE
Welcome back phone number

### DIFF
--- a/packages/scripts/dist/welcome-back.js
+++ b/packages/scripts/dist/welcome-back.js
@@ -45,6 +45,7 @@ export class WelcomeBack {
             region: ENGrid.getFieldValue("supporter.region"),
             postcode: ENGrid.getFieldValue("supporter.postcode"),
             country: ENGrid.getFieldValue("supporter.country"),
+            mobilePhone: ENGrid.getFieldValue("supporter.phoneNumber2"),
         };
         this.addWelcomeBack();
         this.addPersonalDetailsSummary();
@@ -99,6 +100,9 @@ export class WelcomeBack {
         ${this.supporterDetails["firstName"]} ${this.supporterDetails["lastName"]}
         <br>
         ${this.supporterDetails["emailAddress"]}
+        ${this.supporterDetails["mobilePhone"]
+            ? `<br>${this.supporterDetails["mobilePhone"]}`
+            : ""}
      </p>
     `);
         if (this.supporterDetails["address1"] &&

--- a/packages/scripts/src/welcome-back.ts
+++ b/packages/scripts/src/welcome-back.ts
@@ -47,6 +47,7 @@ export class WelcomeBack {
       region: ENGrid.getFieldValue("supporter.region"),
       postcode: ENGrid.getFieldValue("supporter.postcode"),
       country: ENGrid.getFieldValue("supporter.country"),
+      mobilePhone: ENGrid.getFieldValue("supporter.phoneNumber2"),
     };
 
     this.addWelcomeBack();
@@ -133,9 +134,16 @@ export class WelcomeBack {
       "beforeend",
       `
      <p>
-        ${this.supporterDetails["firstName"]} ${this.supporterDetails["lastName"]}
+        ${this.supporterDetails["firstName"]} ${
+        this.supporterDetails["lastName"]
+      }
         <br>
         ${this.supporterDetails["emailAddress"]}
+        ${
+          this.supporterDetails["mobilePhone"]
+            ? `<br>${this.supporterDetails["mobilePhone"]}`
+            : ""
+        }
      </p>
     `
     );


### PR DESCRIPTION
Adds an extra line containing mobile phone number to the welcome back "your information" widget.

This should not change the activation conditions for the widget. If phone number is not present, then the widget may still display, but without a phone number.