### PR TITLE
fix: clear engrid-autofill on not me click

### DIFF
--- a/packages/scripts/dist/welcome-back.d.ts
+++ b/packages/scripts/dist/welcome-back.d.ts
@@ -9,6 +9,7 @@ export declare class WelcomeBack {
     private shouldRun;
     private addWelcomeBack;
     private resetWelcomeBack;
+    private removeAutoFillWithIframe;
     private addPersonalDetailsSummary;
     private addEventListeners;
     enOnValidate(): void;

--- a/packages/scripts/dist/welcome-back.js
+++ b/packages/scripts/dist/welcome-back.js
@@ -73,18 +73,29 @@ export class WelcomeBack {
             .querySelector(options.anchor)) === null || _a === void 0 ? void 0 : _a.insertAdjacentElement(options.placement, welcomeBack);
     }
     resetWelcomeBack() {
-        const inputs = document.querySelectorAll(".fast-personal-details .en__field__input");
-        inputs.forEach((input) => {
-            if (input.type === "checkbox" || input.type === "radio") {
-                input.checked = false;
-            }
-            else {
-                input.value = "";
-            }
-        });
+        const clearAutofillLink = document.getElementById("clear-autofill-data");
+        if (clearAutofillLink) {
+            clearAutofillLink.click();
+        }
         this.supporterDetails = {};
         ENGrid.setBodyData("hide-fast-personal-details", false);
         cookie.remove("engrid-autofill");
+        this.removeAutoFillWithIframe();
+    }
+    removeAutoFillWithIframe() {
+        const rememberMeOptions = ENGrid.getOption("RememberMe");
+        const iframe = document.querySelector('iframe[title="Remember Me iframe"]');
+        if (rememberMeOptions && iframe && iframe.contentWindow) {
+            const cookieName = typeof rememberMeOptions === "object" && rememberMeOptions.cookieName
+                ? rememberMeOptions.cookieName
+                : "engrid-autofill";
+            iframe.contentWindow.postMessage(JSON.stringify({
+                key: cookieName,
+                value: {},
+                operation: "write",
+                expires: 1,
+            }), "*");
+        }
     }
     addPersonalDetailsSummary() {
         var _a;
@@ -125,8 +136,17 @@ export class WelcomeBack {
             .querySelector(options.anchor)) === null || _a === void 0 ? void 0 : _a.insertAdjacentElement(options.placement, personalDetailsSummary);
     }
     addEventListeners() {
+        // Add listener for "Not you?" link in welcome message
         document
             .querySelectorAll(".engrid-reset-welcome-back")
+            .forEach((element) => {
+            element.addEventListener("click", () => {
+                this.resetWelcomeBack();
+            });
+        });
+        // Add listener for "Change" button in personal details summary
+        document
+            .querySelectorAll(".engrid-welcome-back-clear")
             .forEach((element) => {
             element.addEventListener("click", () => {
                 this.resetWelcomeBack();


### PR DESCRIPTION
This PR implements a new function `removeAutoFillWithIframe` on WelcomeBack component to fix issue #374. The function successfully clears engrid-autofill cookie, but for some reason, when it is called, the autofilled fields are not cleared and fast-form-fil resets `hide-fast-personal-details` to true. 

To address this, I updated the resetWelcomeBack function to programmatically trigger a click on the .clear-autofill-data link.

With this changes, the cookie is cleared and fields are shown, as expected:

https://github.com/user-attachments/assets/eb535b06-b866-459c-94a9-16268d29b1ad


