### PR TITLE
Add option for using a proxy to AtData Safe To Send API for FreshAddress Component

### DIFF
--- a/packages/scripts/dist/freshaddress.d.ts
+++ b/packages/scripts/dist/freshaddress.d.ts
@@ -15,4 +15,6 @@ export declare class FreshAddress {
     private callAPI;
     private validateResponse;
     private validate;
+    private callProxy;
+    private validateProxyResponse;
 }

--- a/packages/scripts/dist/freshaddress.js
+++ b/packages/scripts/dist/freshaddress.js
@@ -273,7 +273,5 @@ export class FreshAddress {
                 ENGrid.setError(this.emailWrapper, `This email address is not valid. Did you mean ${res.email_corrections[0]}?`);
             }
         }
-        window.FreshAddressStatus = "idle";
-        ENGrid.enableSubmit();
     }
 }

--- a/packages/scripts/dist/freshaddress.js
+++ b/packages/scripts/dist/freshaddress.js
@@ -9,6 +9,7 @@ import { ENGrid, EngridLogger } from ".";
 import { EnForm } from "./events";
 export class FreshAddress {
     constructor() {
+        var _a;
         this.form = EnForm.getInstance();
         this.emailField = null;
         this.emailWrapper = document.querySelector(".en__field--emailAddress");
@@ -18,8 +19,10 @@ export class FreshAddress {
         this.logger = new EngridLogger("FreshAddress", "#039bc4", "#dfdfdf", "📧");
         this.shouldRun = true;
         this.options = ENGrid.getOption("FreshAddress");
-        if (this.options === false || !window.FreshAddress)
+        if (this.options === false ||
+            (!window.FreshAddress && !((_a = this.options) === null || _a === void 0 ? void 0 : _a.proxyUrl))) {
             return;
+        }
         this.emailField = document.getElementById("en__field_supporter_emailAddress");
         if (this.emailField) {
             this.createFields();
@@ -89,7 +92,12 @@ export class FreshAddress {
                 return;
             }
             this.logger.log("Validating " + ((_b = this.emailField) === null || _b === void 0 ? void 0 : _b.value));
-            this.callAPI();
+            if (this.options && this.options.proxyUrl) {
+                this.callProxy();
+            }
+            else {
+                this.callAPI();
+            }
         });
         // Add event listener to submit
         this.form.onValidate.subscribe(this.validate.bind(this));
@@ -192,7 +200,7 @@ export class FreshAddress {
         else if (this.faStatus.value === "Invalid") {
             this.form.validate = false;
             window.setTimeout(() => {
-                ENGrid.setError(this.emailWrapper, this.faMessage.value);
+                ENGrid.setError(this.emailWrapper, "This email address is not valid.");
             }, 100);
             (_a = this.emailField) === null || _a === void 0 ? void 0 : _a.focus();
             ENGrid.enableSubmit();
@@ -200,5 +208,72 @@ export class FreshAddress {
         }
         this.form.validate = true;
         return true;
+    }
+    callProxy() {
+        var _a;
+        if (!this.options || !this.shouldRun)
+            return;
+        window.FreshAddressStatus = "validating";
+        ENGrid.disableSubmit("Validating Email Address...");
+        fetch(this.options.proxyUrl, {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify({ email: (_a = this.emailField) === null || _a === void 0 ? void 0 : _a.value }),
+            signal: AbortSignal.timeout(5000),
+        })
+            .then((response) => {
+            if (!response.ok) {
+                throw new Error(`HTTP error ${response.status}`);
+            }
+            return response.json();
+        })
+            .then((data) => {
+            this.logger.log("Proxy API Response", data);
+            this.validateProxyResponse(data);
+        })
+            .catch((error) => {
+            if (error.name === "AbortError") {
+                this.logger.log("Proxy API request timed out");
+                this.writeToFields("Request Timeout", "The request took too long.");
+            }
+            else {
+                this.logger.log("Proxy API Error", error);
+                this.writeToFields("Service Error", error.toString());
+            }
+        })
+            .finally(() => {
+            window.FreshAddressStatus = "idle";
+            ENGrid.enableSubmit();
+        });
+    }
+    /*
+     * Validate a request proxied to AtData's Safe To Send API.
+     * https://docs.atdata.com/reference/safe-to-send
+     * https://docs.atdata.com/reference/email-status
+     * https://docs.atdata.com/reference/status-codes-safe-to-send
+     */
+    validateProxyResponse(data) {
+        var _a;
+        // If response is not in expected format, log error and let through.
+        if (!data.safe_to_send) {
+            this.logger.log("Invalid Proxy Response");
+            this.writeToFields("Service Error", "Invalid Proxy Response");
+            return true;
+        }
+        const res = data.safe_to_send;
+        ENGrid.removeError(this.emailWrapper);
+        this.writeToFields(res.status, res.status_code);
+        if (["invalid", "trap"].includes(res.status)) {
+            this.writeToFields("Invalid", res.status_code); // Must be "Invalid" to trigger validation error on submit
+            ENGrid.setError(this.emailWrapper, "This email address is not valid.");
+            (_a = this.emailField) === null || _a === void 0 ? void 0 : _a.focus();
+            if (res.email_corrections && res.email_corrections.length > 0) {
+                ENGrid.setError(this.emailWrapper, `This email address is not valid. Did you mean ${res.email_corrections[0]}?`);
+            }
+        }
+        window.FreshAddressStatus = "idle";
+        ENGrid.enableSubmit();
     }
 }

--- a/packages/scripts/dist/interfaces/options.d.ts
+++ b/packages/scripts/dist/interfaces/options.d.ts
@@ -28,6 +28,7 @@ export interface Options {
         dateFieldFormat?: string;
         statusField?: string;
         messageField?: string;
+        proxyUrl?: string;
     };
     ProgressBar?: boolean | null;
     AutoYear?: boolean;

--- a/packages/scripts/src/freshaddress.ts
+++ b/packages/scripts/src/freshaddress.ts
@@ -30,7 +30,12 @@ export class FreshAddress {
 
   constructor() {
     this.options = ENGrid.getOption("FreshAddress") as Options["FreshAddress"];
-    if (this.options === false || !window.FreshAddress) return;
+    if (
+      this.options === false ||
+      (!window.FreshAddress && !this.options?.proxyUrl)
+    ) {
+      return;
+    }
     this.emailField = document.getElementById(
       "en__field_supporter_emailAddress"
     ) as HTMLInputElement;
@@ -111,7 +116,12 @@ export class FreshAddress {
         return;
       }
       this.logger.log("Validating " + this.emailField?.value);
-      this.callAPI();
+
+      if (this.options && this.options.proxyUrl) {
+        this.callProxy();
+      } else {
+        this.callAPI();
+      }
     });
 
     // Add event listener to submit
@@ -135,6 +145,7 @@ export class FreshAddress {
       }
     );
   }
+
   private validateResponse(data: any) {
     /* ERROR HANDLING: Let through in case of a service error. Enable form submission. */
     if (data.isServiceError()) {
@@ -188,6 +199,7 @@ export class FreshAddress {
     window.FreshAddressStatus = "idle";
     ENGrid.enableSubmit();
   }
+
   private validate() {
     ENGrid.removeError(this.emailWrapper);
     if (!this.form.validate) return;
@@ -220,7 +232,7 @@ export class FreshAddress {
     } else if (this.faStatus!.value === "Invalid") {
       this.form.validate = false;
       window.setTimeout(() => {
-        ENGrid.setError(this.emailWrapper, this.faMessage!.value);
+        ENGrid.setError(this.emailWrapper, "This email address is not valid.");
       }, 100);
       this.emailField?.focus();
       ENGrid.enableSubmit();
@@ -228,5 +240,79 @@ export class FreshAddress {
     }
     this.form.validate = true;
     return true;
+  }
+
+  private callProxy() {
+    if (!this.options || !this.shouldRun) return;
+
+    window.FreshAddressStatus = "validating";
+    ENGrid.disableSubmit("Validating Email Address...");
+
+    fetch(this.options!.proxyUrl!, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ email: this.emailField?.value }),
+      signal: AbortSignal.timeout(5000),
+    })
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error(`HTTP error ${response.status}`);
+        }
+        return response.json();
+      })
+      .then((data) => {
+        this.logger.log("Proxy API Response", data);
+        this.validateProxyResponse(data);
+      })
+      .catch((error) => {
+        if (error.name === "AbortError") {
+          this.logger.log("Proxy API request timed out");
+          this.writeToFields("Request Timeout", "The request took too long.");
+        } else {
+          this.logger.log("Proxy API Error", error);
+          this.writeToFields("Service Error", error.toString());
+        }
+      })
+      .finally(() => {
+        window.FreshAddressStatus = "idle";
+        ENGrid.enableSubmit();
+      });
+  }
+
+  /*
+   * Validate a request proxied to AtData's Safe To Send API.
+   * https://docs.atdata.com/reference/safe-to-send
+   * https://docs.atdata.com/reference/email-status
+   * https://docs.atdata.com/reference/status-codes-safe-to-send
+   */
+  private validateProxyResponse(data: any) {
+    // If response is not in expected format, log error and let through.
+    if (!data.safe_to_send) {
+      this.logger.log("Invalid Proxy Response");
+      this.writeToFields("Service Error", "Invalid Proxy Response");
+      return true;
+    }
+
+    const res = data.safe_to_send;
+
+    ENGrid.removeError(this.emailWrapper);
+    this.writeToFields(res.status, res.status_code);
+
+    if (["invalid", "trap"].includes(res.status)) {
+      this.writeToFields("Invalid", res.status_code); // Must be "Invalid" to trigger validation error on submit
+      ENGrid.setError(this.emailWrapper, "This email address is not valid.");
+      this.emailField?.focus();
+      if (res.email_corrections && res.email_corrections.length > 0) {
+        ENGrid.setError(
+          this.emailWrapper,
+          `This email address is not valid. Did you mean ${res.email_corrections[0]}?`
+        );
+      }
+    }
+
+    window.FreshAddressStatus = "idle";
+    ENGrid.enableSubmit();
   }
 }

--- a/packages/scripts/src/freshaddress.ts
+++ b/packages/scripts/src/freshaddress.ts
@@ -311,8 +311,5 @@ export class FreshAddress {
         );
       }
     }
-
-    window.FreshAddressStatus = "idle";
-    ENGrid.enableSubmit();
   }
 }

--- a/packages/scripts/src/interfaces/options.ts
+++ b/packages/scripts/src/interfaces/options.ts
@@ -30,6 +30,7 @@ export interface Options {
         dateFieldFormat?: string;
         statusField?: string;
         messageField?: string;
+        proxyUrl?: string;
       };
   ProgressBar?: boolean | null;
   AutoYear?: boolean;


### PR DESCRIPTION
A new option has been added to the FreshAddress Component `proxyUrl`. This accepts a URL hosting a proxy to the AtData SafeToSendAPI: https://docs.atdata.com/reference/safe-to-send that returns the same structure as that API endpoint does.

This addition attempts to gracefully integrate with the current component with as few changes as possible and re-using patterns already defined by the component. When a `proxyUrl` option is provided, we simply substitute the API call and response handling to 2 new functions.

**Differences from current implementation**
* The SendToSafe API does not return error messages but instead returns status codes https://docs.atdata.com/reference/status-codes-safe-to-send. These codes are inserted into the "faMessage" field.
* The SendToSafe API does not have configurable rejection for different statuses, so we have implemented to reject "invalid" and "trap" statuses. The "unknown" status could be added too but it is rare and in my testing it is a false positive.https://docs.atdata.com/reference/email-status
* The API does not return defined error messages so we use the fixed error message "This email address is not valid." When the API returns an email suggestion, we also add "Did you mean {first suggestion}?"

**Redundancies and Fallbacks**
These are in place to handle:
* The API not responding
* The API returns an error
* The API returns a response in an unexpected format
* The API request times out (5 seconds)

In these cases the form is allowed to be submitted.

**Testing**
Related Productive task: https://app.productive.io/2650-4site-interactive-studios-inc/tasks/16274112

The page can be tested on WWF's pages using a branch I built from this branch that is configured to use their proxy:

https://protect.worldwildlife.org/page/94262/donate/1?assets=fresh-address-proxy

**Testing Criteria**

- [ ] Email addresses are correctly marked as valid when valid and the form can submit
- [ ] Email addresses are correctly marked as invalid and the form submission is blocked
- [ ] Email suggestion is displayed in error message when the API provides one.
- [ ] When the API does not respond, I can still submit the form.
- [ ] When the API returns an error, I can still submit the form.
- [ ] When the API returns a response in an unexpected format, I can still submit the form.
- [ ] When the API request times out, I can still submit the form.
- [ ] 4Site Email Addresses bypasses the validation
- [ ] Status, Message and Date field values are properly recorded (if applicable to client)
- [ ] After submitting an invalid email, then changing to a valid email, I can submit the form.
- [ ] When not using a `proxyUrl`, everything works as it did before.