### PR TITLE
Fresh address proxy

### DIFF
--- a/packages/scripts/dist/freshaddress.js
+++ b/packages/scripts/dist/freshaddress.js
@@ -287,6 +287,7 @@ export class FreshAddress {
             ENGrid.setError(this.emailWrapper, "This email address is not valid.");
             (_a = this.emailField) === null || _a === void 0 ? void 0 : _a.focus();
             if (res.email_corrections && res.email_corrections.length > 0) {
+                this.emailField.value = res.email_corrections[0];
                 ENGrid.setError(this.emailWrapper, `This email address is not valid. Did you mean ${res.email_corrections[0]}?`);
             }
         }

--- a/packages/scripts/src/freshaddress.ts
+++ b/packages/scripts/src/freshaddress.ts
@@ -329,6 +329,7 @@ export class FreshAddress {
       ENGrid.setError(this.emailWrapper, "This email address is not valid.");
       this.emailField?.focus();
       if (res.email_corrections && res.email_corrections.length > 0) {
+        this.emailField!.value = res.email_corrections[0];
         ENGrid.setError(
           this.emailWrapper,
           `This email address is not valid. Did you mean ${res.email_corrections[0]}?`


### PR DESCRIPTION
Further updates to the FreshAddress Proxy to add basic email format checking before using the API, and also the handle 422 responses. Added auto correction of email typos.

https://protect.worldwildlife.org/page/92206/donate/1?assets=fresh-address-proxy&debug=log