### PR TITLE
Option to supress gift related events to dataLayer when on eCard pages

### DIFF
--- a/packages/scripts/dist/data-layer.d.ts
+++ b/packages/scripts/dist/data-layer.d.ts
@@ -5,6 +5,7 @@ export declare class DataLayer {
     private static instance;
     private encoder;
     private endOfGiftProcessStorageKey;
+    private giftFields;
     private excludedFields;
     private hashedFields;
     private retainedEmailField;

--- a/packages/scripts/dist/data-layer.js
+++ b/packages/scripts/dist/data-layer.js
@@ -35,7 +35,7 @@ export class DataLayer {
             "receiptNumber",
             "recurring",
             "transactionId",
-            "transactionType"
+            "transactionType",
         ];
         this.excludedFields = [
             // Credit Card
@@ -115,12 +115,15 @@ export class DataLayer {
     onLoad() {
         // Collect all data layer variables to push at once
         const dataLayerData = {};
+        const suppressEcardData = ENGrid.getPageType() === "ECARD" &&
+            ENGrid.getOption("SuppressPurchaseEcard");
         if (ENGrid.getGiftProcess()) {
             // EN will chain together gift process data on the page json when redirecting from a completed donation to an ecard.
-            // Since the ecard page can be embedded on the thank you page of a donation, this can cause confusion in the data layer with events 
+            // Since the ecard page can be embedded on the thank you page of a donation, this can cause confusion in the data layer with events
             // firing for both the donation and the ecard on the same page.
-            if (ENGrid.getPageType() === "ECARD" && ENGrid.getOption("SuppressPurchaseEcard")) {
+            if (suppressEcardData) {
                 this.logger.log("⛔ Gift process was detected BUT suppressing EN_SUCCESSFUL_DONATION event due to SuppressPurchaseEcard option enabled");
+                window.sessionStorage.removeItem(this.endOfGiftProcessStorageKey);
             }
             else {
                 this.logger.log("EN_SUCCESSFUL_DONATION");
@@ -128,9 +131,9 @@ export class DataLayer {
             }
         }
         if (window.pageJson) {
-            let pageJson = window.pageJson;
+            const pageJson = window.pageJson;
             for (const property in pageJson) {
-                if (ENGrid.getPageType() === "ECARD" && ENGrid.getOption("SuppressPurchaseEcard") && this.giftFields.includes(property)) {
+                if (suppressEcardData && this.giftFields.includes(property)) {
                     continue;
                 }
                 const key = `EN_PAGEJSON_${property.toUpperCase()}`;

--- a/packages/scripts/dist/data-layer.js
+++ b/packages/scripts/dist/data-layer.js
@@ -24,6 +24,19 @@ export class DataLayer {
         this._form = EnForm.getInstance();
         this.encoder = new TextEncoder();
         this.endOfGiftProcessStorageKey = "ENGRID_END_OF_GIFT_PROCESS_EVENTS";
+        // pageJson entries related to the gift process
+        this.giftFields = [
+            "amount",
+            "currency",
+            "donationLogId",
+            "feeCover",
+            "giftProcess",
+            "paymentType",
+            "receiptNumber",
+            "recurring",
+            "transactionId",
+            "transactionType"
+        ];
         this.excludedFields = [
             // Credit Card
             "transaction.ccnumber",
@@ -103,11 +116,21 @@ export class DataLayer {
         // Collect all data layer variables to push at once
         const dataLayerData = {};
         if (ENGrid.getGiftProcess()) {
+            // EN will chain together gift process data on the page json when redirecting from a completed donation to an ecard.
+            // Since the ecard page can be embedded on the thank you page of a donation, this can cause confusion in the data layer with events 
+            // firing for both the donation and the ecard on the same page.
+            if (ENGrid.getPageType() === "ECARD" && ENGrid.getOption("SupressPurchaseEcard")) {
+                this.logger.log("⛔ Gift process was detected BUT supressing EN_SUCCESSFUL_DONATIO event due to SupressPurchaseEcard option enabled");
+                return;
+            }
             this.logger.log("EN_SUCCESSFUL_DONATION");
             this.addEndOfGiftProcessEventsToDataLayer();
         }
         if (window.pageJson) {
-            const pageJson = window.pageJson;
+            let pageJson = window.pageJson;
+            if (ENGrid.getPageType() === "ECARD" && ENGrid.getOption("SupressPurchaseEcard")) {
+                pageJson = pageJson.filter((entry) => !this.giftFields.includes(entry.key));
+            }
             for (const property in pageJson) {
                 const key = `EN_PAGEJSON_${property.toUpperCase()}`;
                 const value = pageJson[property];

--- a/packages/scripts/dist/data-layer.js
+++ b/packages/scripts/dist/data-layer.js
@@ -119,8 +119,8 @@ export class DataLayer {
             // EN will chain together gift process data on the page json when redirecting from a completed donation to an ecard.
             // Since the ecard page can be embedded on the thank you page of a donation, this can cause confusion in the data layer with events 
             // firing for both the donation and the ecard on the same page.
-            if (ENGrid.getPageType() === "ECARD" && ENGrid.getOption("SupressPurchaseEcard")) {
-                this.logger.log("⛔ Gift process was detected BUT supressing EN_SUCCESSFUL_DONATIO event due to SupressPurchaseEcard option enabled");
+            if (ENGrid.getPageType() === "ECARD" && ENGrid.getOption("SuppressPurchaseEcard")) {
+                this.logger.log("⛔ Gift process was detected BUT suppressing EN_SUCCESSFUL_DONATION event due to SuppressPurchaseEcard option enabled");
                 return;
             }
             this.logger.log("EN_SUCCESSFUL_DONATION");
@@ -128,7 +128,7 @@ export class DataLayer {
         }
         if (window.pageJson) {
             let pageJson = window.pageJson;
-            if (ENGrid.getPageType() === "ECARD" && ENGrid.getOption("SupressPurchaseEcard")) {
+            if (ENGrid.getPageType() === "ECARD" && ENGrid.getOption("SuppressPurchaseEcard")) {
                 pageJson = pageJson.filter((entry) => !this.giftFields.includes(entry.key));
             }
             for (const property in pageJson) {

--- a/packages/scripts/dist/data-layer.js
+++ b/packages/scripts/dist/data-layer.js
@@ -129,10 +129,10 @@ export class DataLayer {
         }
         if (window.pageJson) {
             let pageJson = window.pageJson;
-            if (ENGrid.getPageType() === "ECARD" && ENGrid.getOption("SuppressPurchaseEcard")) {
-                pageJson = pageJson.filter((entry) => !this.giftFields.includes(entry.key));
-            }
             for (const property in pageJson) {
+                if (ENGrid.getPageType() === "ECARD" && ENGrid.getOption("SuppressPurchaseEcard") && this.giftFields.includes(property)) {
+                    continue;
+                }
                 const key = `EN_PAGEJSON_${property.toUpperCase()}`;
                 const value = pageJson[property];
                 dataLayerData[key] = this.transformJSON(value);

--- a/packages/scripts/dist/data-layer.js
+++ b/packages/scripts/dist/data-layer.js
@@ -121,10 +121,11 @@ export class DataLayer {
             // firing for both the donation and the ecard on the same page.
             if (ENGrid.getPageType() === "ECARD" && ENGrid.getOption("SuppressPurchaseEcard")) {
                 this.logger.log("⛔ Gift process was detected BUT suppressing EN_SUCCESSFUL_DONATION event due to SuppressPurchaseEcard option enabled");
-                return;
             }
-            this.logger.log("EN_SUCCESSFUL_DONATION");
-            this.addEndOfGiftProcessEventsToDataLayer();
+            else {
+                this.logger.log("EN_SUCCESSFUL_DONATION");
+                this.addEndOfGiftProcessEventsToDataLayer();
+            }
         }
         if (window.pageJson) {
             let pageJson = window.pageJson;

--- a/packages/scripts/dist/interfaces/options.d.ts
+++ b/packages/scripts/dist/interfaces/options.d.ts
@@ -18,7 +18,7 @@ export interface Options {
     UseAmountValidatorFromEN?: boolean;
     SkipToMainContentLink?: boolean;
     SrcDefer?: boolean;
-    SupressPurchaseEcard?: boolean;
+    SuppressPurchaseEcard?: boolean;
     NeverBounceAPI?: string | null;
     NeverBounceDateField?: string | null;
     NeverBounceDateFormat?: string;

--- a/packages/scripts/dist/interfaces/options.d.ts
+++ b/packages/scripts/dist/interfaces/options.d.ts
@@ -18,6 +18,7 @@ export interface Options {
     UseAmountValidatorFromEN?: boolean;
     SkipToMainContentLink?: boolean;
     SrcDefer?: boolean;
+    SupressPurchaseEcard?: boolean;
     NeverBounceAPI?: string | null;
     NeverBounceDateField?: string | null;
     NeverBounceDateFormat?: string;

--- a/packages/scripts/dist/interfaces/options.js
+++ b/packages/scripts/dist/interfaces/options.js
@@ -17,7 +17,7 @@ export const OptionsDefaults = {
     UseAmountValidatorFromEN: false,
     SkipToMainContentLink: true,
     SrcDefer: true,
-    SupressPurchaseEcard: false,
+    SuppressPurchaseEcard: false,
     NeverBounceAPI: null,
     NeverBounceDateField: null,
     NeverBounceStatusField: null,

--- a/packages/scripts/dist/interfaces/options.js
+++ b/packages/scripts/dist/interfaces/options.js
@@ -17,6 +17,7 @@ export const OptionsDefaults = {
     UseAmountValidatorFromEN: false,
     SkipToMainContentLink: true,
     SrcDefer: true,
+    SupressPurchaseEcard: false,
     NeverBounceAPI: null,
     NeverBounceDateField: null,
     NeverBounceStatusField: null,

--- a/packages/scripts/src/data-layer.ts
+++ b/packages/scripts/src/data-layer.ts
@@ -23,6 +23,20 @@ export class DataLayer {
   private encoder = new TextEncoder();
   private endOfGiftProcessStorageKey = "ENGRID_END_OF_GIFT_PROCESS_EVENTS";
 
+  // pageJson entries related to the gift process
+  private giftFields = [
+    "amount",
+    "currency",
+    "donationLogId",
+    "feeCover",
+    "giftProcess",
+    "paymentType",
+    "receiptNumber",
+    "recurring",
+    "transactionId",
+    "transactionType"
+  ]
+
   private excludedFields = [
     // Credit Card
     "transaction.ccnumber",
@@ -113,12 +127,22 @@ export class DataLayer {
     const dataLayerData: { [key: string]: any } = {};
 
     if (ENGrid.getGiftProcess()) {
+      // EN will chain together gift process data on the page json when redirecting from a completed donation to an ecard.
+      // Since the ecard page can be embedded on the thank you page of a donation, this can cause confusion in the data layer with events 
+      // firing for both the donation and the ecard on the same page.
+      if(ENGrid.getPageType() === "ECARD" && ENGrid.getOption("SupressPurchaseEcard")) {
+        this.logger.log("⛔ Gift process was detected BUT supressing EN_SUCCESSFUL_DONATIO event due to SupressPurchaseEcard option enabled");
+        return;
+      }
       this.logger.log("EN_SUCCESSFUL_DONATION");
       this.addEndOfGiftProcessEventsToDataLayer();
     }
 
     if (window.pageJson) {
-      const pageJson = window.pageJson as Record<string, any>;
+      let pageJson = window.pageJson as Record<string, any>;
+      if(ENGrid.getPageType() === "ECARD" && ENGrid.getOption("SupressPurchaseEcard")) {
+        pageJson = pageJson.filter((entry: Record<string,any>) => !this.giftFields.includes(entry.key));
+      }
       for (const property in pageJson) {
         const key = `EN_PAGEJSON_${property.toUpperCase()}`;
         const value = pageJson[property];

--- a/packages/scripts/src/data-layer.ts
+++ b/packages/scripts/src/data-layer.ts
@@ -131,7 +131,7 @@ export class DataLayer {
       // Since the ecard page can be embedded on the thank you page of a donation, this can cause confusion in the data layer with events 
       // firing for both the donation and the ecard on the same page.
       if(ENGrid.getPageType() === "ECARD" && ENGrid.getOption("SupressPurchaseEcard")) {
-        this.logger.log("⛔ Gift process was detected BUT supressing EN_SUCCESSFUL_DONATIO event due to SupressPurchaseEcard option enabled");
+        this.logger.log("⛔ Gift process was detected BUT supressing EN_SUCCESSFUL_DONATION event due to SupressPurchaseEcard option enabled");
         return;
       }
       this.logger.log("EN_SUCCESSFUL_DONATION");

--- a/packages/scripts/src/data-layer.ts
+++ b/packages/scripts/src/data-layer.ts
@@ -130,8 +130,8 @@ export class DataLayer {
       // EN will chain together gift process data on the page json when redirecting from a completed donation to an ecard.
       // Since the ecard page can be embedded on the thank you page of a donation, this can cause confusion in the data layer with events 
       // firing for both the donation and the ecard on the same page.
-      if(ENGrid.getPageType() === "ECARD" && ENGrid.getOption("SupressPurchaseEcard")) {
-        this.logger.log("⛔ Gift process was detected BUT supressing EN_SUCCESSFUL_DONATION event due to SupressPurchaseEcard option enabled");
+      if(ENGrid.getPageType() === "ECARD" && ENGrid.getOption("SuppressPurchaseEcard")) {
+        this.logger.log("⛔ Gift process was detected BUT suppressing EN_SUCCESSFUL_DONATION event due to SuppressPurchaseEcard option enabled");
         return;
       }
       this.logger.log("EN_SUCCESSFUL_DONATION");
@@ -140,7 +140,7 @@ export class DataLayer {
 
     if (window.pageJson) {
       let pageJson = window.pageJson as Record<string, any>;
-      if(ENGrid.getPageType() === "ECARD" && ENGrid.getOption("SupressPurchaseEcard")) {
+      if(ENGrid.getPageType() === "ECARD" && ENGrid.getOption("SuppressPurchaseEcard")) {
         pageJson = pageJson.filter((entry: Record<string,any>) => !this.giftFields.includes(entry.key));
       }
       for (const property in pageJson) {

--- a/packages/scripts/src/data-layer.ts
+++ b/packages/scripts/src/data-layer.ts
@@ -132,10 +132,10 @@ export class DataLayer {
       // firing for both the donation and the ecard on the same page.
       if(ENGrid.getPageType() === "ECARD" && ENGrid.getOption("SuppressPurchaseEcard")) {
         this.logger.log("⛔ Gift process was detected BUT suppressing EN_SUCCESSFUL_DONATION event due to SuppressPurchaseEcard option enabled");
-        return;
+      } else {
+        this.logger.log("EN_SUCCESSFUL_DONATION");
+        this.addEndOfGiftProcessEventsToDataLayer();
       }
-      this.logger.log("EN_SUCCESSFUL_DONATION");
-      this.addEndOfGiftProcessEventsToDataLayer();
     }
 
     if (window.pageJson) {

--- a/packages/scripts/src/data-layer.ts
+++ b/packages/scripts/src/data-layer.ts
@@ -34,8 +34,8 @@ export class DataLayer {
     "receiptNumber",
     "recurring",
     "transactionId",
-    "transactionType"
-  ]
+    "transactionType",
+  ];
 
   private excludedFields = [
     // Credit Card
@@ -125,13 +125,19 @@ export class DataLayer {
   private onLoad() {
     // Collect all data layer variables to push at once
     const dataLayerData: { [key: string]: any } = {};
+    const suppressEcardData =
+      ENGrid.getPageType() === "ECARD" &&
+      ENGrid.getOption("SuppressPurchaseEcard");
 
     if (ENGrid.getGiftProcess()) {
       // EN will chain together gift process data on the page json when redirecting from a completed donation to an ecard.
-      // Since the ecard page can be embedded on the thank you page of a donation, this can cause confusion in the data layer with events 
+      // Since the ecard page can be embedded on the thank you page of a donation, this can cause confusion in the data layer with events
       // firing for both the donation and the ecard on the same page.
-      if(ENGrid.getPageType() === "ECARD" && ENGrid.getOption("SuppressPurchaseEcard")) {
-        this.logger.log("⛔ Gift process was detected BUT suppressing EN_SUCCESSFUL_DONATION event due to SuppressPurchaseEcard option enabled");
+      if (suppressEcardData) {
+        this.logger.log(
+          "⛔ Gift process was detected BUT suppressing EN_SUCCESSFUL_DONATION event due to SuppressPurchaseEcard option enabled"
+        );
+        window.sessionStorage.removeItem(this.endOfGiftProcessStorageKey);
       } else {
         this.logger.log("EN_SUCCESSFUL_DONATION");
         this.addEndOfGiftProcessEventsToDataLayer();
@@ -139,9 +145,9 @@ export class DataLayer {
     }
 
     if (window.pageJson) {
-      let pageJson = window.pageJson as Record<string, any>;
+      const pageJson = window.pageJson as Record<string, any>;
       for (const property in pageJson) {
-        if(ENGrid.getPageType() === "ECARD" && ENGrid.getOption("SuppressPurchaseEcard") && this.giftFields.includes(property) ) {
+        if (suppressEcardData && this.giftFields.includes(property)) {
           continue;
         }
         const key = `EN_PAGEJSON_${property.toUpperCase()}`;

--- a/packages/scripts/src/data-layer.ts
+++ b/packages/scripts/src/data-layer.ts
@@ -140,10 +140,10 @@ export class DataLayer {
 
     if (window.pageJson) {
       let pageJson = window.pageJson as Record<string, any>;
-      if(ENGrid.getPageType() === "ECARD" && ENGrid.getOption("SuppressPurchaseEcard")) {
-        pageJson = pageJson.filter((entry: Record<string,any>) => !this.giftFields.includes(entry.key));
-      }
       for (const property in pageJson) {
+        if(ENGrid.getPageType() === "ECARD" && ENGrid.getOption("SuppressPurchaseEcard") && this.giftFields.includes(property) ) {
+          continue;
+        }
         const key = `EN_PAGEJSON_${property.toUpperCase()}`;
         const value = pageJson[property];
         dataLayerData[key] = this.transformJSON(value);

--- a/packages/scripts/src/interfaces/options.ts
+++ b/packages/scripts/src/interfaces/options.ts
@@ -18,7 +18,7 @@ export interface Options {
   UseAmountValidatorFromEN?: boolean;
   SkipToMainContentLink?: boolean;
   SrcDefer?: boolean;
-  SupressPurchaseEcard?: boolean;
+  SuppressPurchaseEcard?: boolean;
   NeverBounceAPI?: string | null;
   NeverBounceDateField?: string | null;
   NeverBounceDateFormat?: string;
@@ -209,7 +209,7 @@ export const OptionsDefaults: Options = {
   UseAmountValidatorFromEN: false,
   SkipToMainContentLink: true,
   SrcDefer: true,
-  SupressPurchaseEcard: false,
+  SuppressPurchaseEcard: false,
   NeverBounceAPI: null,
   NeverBounceDateField: null,
   NeverBounceStatusField: null,

--- a/packages/scripts/src/interfaces/options.ts
+++ b/packages/scripts/src/interfaces/options.ts
@@ -18,6 +18,7 @@ export interface Options {
   UseAmountValidatorFromEN?: boolean;
   SkipToMainContentLink?: boolean;
   SrcDefer?: boolean;
+  SupressPurchaseEcard?: boolean;
   NeverBounceAPI?: string | null;
   NeverBounceDateField?: string | null;
   NeverBounceDateFormat?: string;
@@ -208,6 +209,7 @@ export const OptionsDefaults: Options = {
   UseAmountValidatorFromEN: false,
   SkipToMainContentLink: true,
   SrcDefer: true,
+  SupressPurchaseEcard: false,
   NeverBounceAPI: null,
   NeverBounceDateField: null,
   NeverBounceStatusField: null,


### PR DESCRIPTION
@bryancasler has conducted preliminary QA already

* For task: https://app.productive.io/2650-4site-interactive-studios-inc/tasks/16619272
* Adds new option in configuration `SupressPurchaseEcard` (default `false`, will not change any existing installations)
* When page type is `ECARD` and this `SupressPurchaseEcard` is true, `DataLayer` module will not report the `EN_SUCCESSFUL_DONATION` event or record payment-related `pageJson` values to `EN_PAGEJSON_XXXX`

## Testing Process
1. Use GTM tag assistant for ats.org, pointed to this page: https://secure.ats.org/page/93557/donate/1
2. Complete the donation form, tick the box that the gift is in honor, and fill out the ecard data, and submit the form
* [Video preview of this process available in this task comment](https://app.productive.io/2650-4site-interactive-studios-inc/task/16619273?taskActivityId=248949140)
3.  Check the tag assistant that the ECard Page does not have a `EN_SUCCESSFUL_DONATION` event
4.  Check the tag assistant that the ECard Page `pageJsonVariablesReady`'s event does **not** contain any gift process variables
 
Gift process variables:
    * `amount`
    * `currency`
    * `donationLogId`
    * `feeCover`
    * `giftProcess`
    * `paymentType`
    * `receiptNumber`
    * `recurring`
    * `transactionId`
    * `transactionType`
    
5.  **Test functionality again** but with `SuppressPurchaseEcard` set to **false**; events should **not** be suppressed.