### PR TITLE
Dont run auto country select if fastform conditions have been met

### DIFF
--- a/packages/scripts/dist/auto-country-select.js
+++ b/packages/scripts/dist/auto-country-select.js
@@ -16,10 +16,15 @@ export class AutoCountrySelect {
             ENGrid.getUrlParameter("supporter.region") ||
             (ENGrid.getUrlParameter("ea.url.id") &&
                 !ENGrid.getUrlParameter("forwarded"));
+        // If fast form is active, then personal details have already been filled somehow and we should not override the country selection
+        // The client is also likely using WelcomeBack.
+        const fastFormActive = ENGrid.getBodyData("hide-fast-address-details") ||
+            ENGrid.getBodyData("hide-fast-personal-details");
         if (!engridAutofill &&
             !submissionFailed &&
             hasIntlSupport &&
-            !locationDataInUrl) {
+            !locationDataInUrl &&
+            !fastFormActive) {
             fetch(`https://${window.location.hostname}/cdn-cgi/trace`)
                 .then((res) => res.text())
                 .then((t) => {

--- a/packages/scripts/src/auto-country-select.ts
+++ b/packages/scripts/src/auto-country-select.ts
@@ -30,11 +30,18 @@ export class AutoCountrySelect {
       (ENGrid.getUrlParameter("ea.url.id") &&
         !ENGrid.getUrlParameter("forwarded"));
 
+    // If fast form is active, then personal details have already been filled somehow and we should not override the country selection
+    // The client is also likely using WelcomeBack.
+    const fastFormActive =
+      ENGrid.getBodyData("hide-fast-address-details") ||
+      ENGrid.getBodyData("hide-fast-personal-details");
+
     if (
       !engridAutofill &&
       !submissionFailed &&
       hasIntlSupport &&
-      !locationDataInUrl
+      !locationDataInUrl &&
+      !fastFormActive
     ) {
       fetch(`https://${window.location.hostname}/cdn-cgi/trace`)
         .then((res) => res.text())


### PR DESCRIPTION
When a supporter visited a page with prefilled details that wasn't covered by existing conditions, the country would be overwritten. If the client is using WelcomeBack, this change would be hidden from the supporter.

The specific case where this was identified is in p2p3 when coming to an ENgrid checkout page from a p2p3 registration, but it could also apply to chained pages.