### PR TITLE
Adds "IntentSubmit" event that supports digital wallet submissions

### DIFF
--- a/packages/scripts/dist/app.d.ts
+++ b/packages/scripts/dist/app.d.ts
@@ -13,6 +13,7 @@ export declare class App extends ENGrid {
     private onLoad;
     private onResize;
     private onValidate;
+    private onIntentSubmit;
     private onSubmit;
     private onError;
     static log(message: string): void;

--- a/packages/scripts/dist/app.js
+++ b/packages/scripts/dist/app.js
@@ -94,6 +94,7 @@ export class App extends ENGrid {
             }
         });
         // Client onSubmit and onError functions
+        this._form.onIntentSubmit.subscribe(() => this.onIntentSubmit());
         this._form.onSubmit.subscribe(() => this.onSubmit());
         this._form.onError.subscribe(() => this.onError());
         this._form.onValidate.subscribe(() => this.onValidate());
@@ -111,6 +112,7 @@ export class App extends ENGrid {
         window.enOnSubmit = () => {
             this._form.submit = true;
             this._form.submitPromise = false;
+            this._form.dispatchIntentSubmit();
             this._form.dispatchSubmit();
             ENGrid.watchForError(ENGrid.enableSubmit);
             if (!this._form.submit)
@@ -329,6 +331,12 @@ export class App extends ENGrid {
         if (this.options.onValidate) {
             this.logger.log("Client onValidate Triggered");
             this.options.onValidate();
+        }
+    }
+    onIntentSubmit() {
+        if (this.options.onIntentSubmit) {
+            this.logger.log("Client onIntentSubmit Triggered");
+            this.options.onIntentSubmit();
         }
     }
     onSubmit() {

--- a/packages/scripts/dist/digital-wallets.d.ts
+++ b/packages/scripts/dist/digital-wallets.d.ts
@@ -1,8 +1,13 @@
 export declare class DigitalWallets {
+    private logger;
+    private _form;
     constructor();
     private addStripeDigitalWallets;
     private addPaypalTouchDigitalWallets;
     private addDAF;
     private addOptionToPaymentTypeField;
     private checkForWalletsBeingAdded;
+    private addPaypalOneTouchListener;
+    private addStripeDigitalWalletListener;
+    private addDAFListener;
 }

--- a/packages/scripts/dist/digital-wallets.js
+++ b/packages/scripts/dist/digital-wallets.js
@@ -119,7 +119,7 @@ export class DigitalWallets {
             : this.logger.log("Failed to add Paypal Touch listener");
     }
     addDAF() {
-        this.logger.log("Donor Advised Fund Digital Wallets detected");
+        this.logger.log("DAF Digital Wallet detected");
         this.addOptionToPaymentTypeField("daf", "Donor Advised Fund");
         ENGrid.setBodyData("payment-type-option-daf", "true");
         this.addDAFListener()
@@ -174,13 +174,16 @@ export class DigitalWallets {
         var _a, _b, _c, _d, _e;
         const paypalTouch = (_d = (_c = (_b = (_a = window.EngagingNetworks) === null || _a === void 0 ? void 0 : _a.require) === null || _b === void 0 ? void 0 : _b._defined) === null || _c === void 0 ? void 0 : _c.enPaypalTouch) === null || _d === void 0 ? void 0 : _d.paypalTouch;
         if (!((_e = paypalTouch === null || paypalTouch === void 0 ? void 0 : paypalTouch.library) === null || _e === void 0 ? void 0 : _e.Buttons)) {
+            this.logger.log("Paypal Touch library not found, cannot add listener");
             return false;
         }
         const buttons = paypalTouch.library.Buttons.bind(paypalTouch.library);
-        paypalTouch.library.Buttons = (o) => buttons(Object.assign(Object.assign({}, o), { onClick: (d, a) => (this._form.dispatchIntentSubmit.bind(this._form),
+        // setTimeout(() => {
+        paypalTouch.library.Buttons = (o) => buttons(Object.assign(Object.assign({}, o), { onClick: (d, a) => (this._form.dispatchIntentSubmit(),
                 o.onClick && o.onClick(d, a)) }));
         paypalTouch.unloadButton && paypalTouch.unloadButton();
         paypalTouch.loadButton && paypalTouch.loadButton();
+        // }, 750);
         return true;
     }
     addStripeDigitalWalletListener() {
@@ -188,8 +191,8 @@ export class DigitalWallets {
         return !!((_f = (_e = (_d = (_c = (_b = (_a = window.EngagingNetworks) === null || _a === void 0 ? void 0 : _a.require) === null || _b === void 0 ? void 0 : _b._defined) === null || _c === void 0 ? void 0 : _c.enStripeButtons) === null || _d === void 0 ? void 0 : _d.stripeButtons) === null || _e === void 0 ? void 0 : _e.paymentRequest) === null || _f === void 0 ? void 0 : _f.on("paymentmethod", this._form.dispatchIntentSubmit.bind(this._form)));
     }
     addDAFListener() {
-        var _a;
-        return !!((_a = document
-            .getElementById("chariot-button")) === null || _a === void 0 ? void 0 : _a.addEventListener("click", this._form.dispatchIntentSubmit.bind(this._form)));
+        const chariotButton = document.getElementById("chariot-button");
+        chariotButton === null || chariotButton === void 0 ? void 0 : chariotButton.addEventListener("click", this._form.dispatchIntentSubmit.bind(this._form));
+        return !!chariotButton;
     }
 }

--- a/packages/scripts/dist/digital-wallets.js
+++ b/packages/scripts/dist/digital-wallets.js
@@ -1,6 +1,10 @@
 import { ENGrid } from "./engrid";
+import { EnForm } from "./events";
+import { EngridLogger } from "./logger";
 export class DigitalWallets {
     constructor() {
+        this.logger = new EngridLogger("DigitalWallets", "#fff", "#333", "👛");
+        this._form = EnForm.getInstance();
         //digital wallets not enabled.
         if (!document.getElementById("en__digitalWallet")) {
             ENGrid.setBodyData("payment-type-option-stripedigitalwallet", "false");
@@ -9,6 +13,7 @@ export class DigitalWallets {
             ENGrid.setBodyData("payment-type-option-paypal-one-touch", "false");
             ENGrid.setBodyData("payment-type-option-venmo", "false");
             ENGrid.setBodyData("payment-type-option-daf", "false");
+            this.logger.log("No digital wallet container found, skipping digital wallet setup.");
             return;
         }
         // Add giveBySelect classes to the separate wallet containers
@@ -86,6 +91,7 @@ export class DigitalWallets {
         }
     }
     addStripeDigitalWallets() {
+        this.logger.log("Stripe Digital Wallets detected");
         this.addOptionToPaymentTypeField("stripedigitalwallet", "GooglePay / ApplePay");
         // ENGrid.setBodyData(
         //   "payment-type-option-apple-pay",
@@ -99,15 +105,26 @@ export class DigitalWallets {
         ENGrid.setBodyData("payment-type-option-apple-pay", "true");
         ENGrid.setBodyData("payment-type-option-google-pay", "true");
         ENGrid.setBodyData("payment-type-option-stripedigitalwallet", "true");
+        this.addStripeDigitalWalletListener()
+            ? this.logger.log("Stripe Digital Wallet listener added successfully")
+            : this.logger.log("Failed to add Stripe Digital Wallet listener");
     }
     addPaypalTouchDigitalWallets() {
+        this.logger.log("Paypal Touch Digital Wallets detected");
         this.addOptionToPaymentTypeField("paypaltouch", "Paypal / Venmo");
         ENGrid.setBodyData("payment-type-option-paypal-one-touch", "true");
         ENGrid.setBodyData("payment-type-option-venmo", "true");
+        this.addPaypalOneTouchListener()
+            ? this.logger.log("Paypal Touch listener added successfully")
+            : this.logger.log("Failed to add Paypal Touch listener");
     }
     addDAF() {
+        this.logger.log("Donor Advised Fund Digital Wallets detected");
         this.addOptionToPaymentTypeField("daf", "Donor Advised Fund");
         ENGrid.setBodyData("payment-type-option-daf", "true");
+        this.addDAFListener()
+            ? this.logger.log("DAF listener added successfully")
+            : this.logger.log("Failed to add DAF listener");
     }
     addOptionToPaymentTypeField(value, label) {
         const paymentTypeField = document.querySelector('[name="transaction.paymenttype"]');
@@ -144,12 +161,35 @@ export class DigitalWallets {
                     else if (walletType === "daf") {
                         this.addDAF();
                     }
-                    //Disconnect observer to prevent multiple additions
+                    //Disconnect observer and break loop to prevent multiple additions
                     observer.disconnect();
+                    break;
                 }
             }
         };
         const observer = new MutationObserver(callback);
         observer.observe(node, { childList: true, subtree: true });
+    }
+    addPaypalOneTouchListener() {
+        var _a, _b, _c, _d, _e;
+        const paypalTouch = (_d = (_c = (_b = (_a = window.EngagingNetworks) === null || _a === void 0 ? void 0 : _a.require) === null || _b === void 0 ? void 0 : _b._defined) === null || _c === void 0 ? void 0 : _c.enPaypalTouch) === null || _d === void 0 ? void 0 : _d.paypalTouch;
+        if (!((_e = paypalTouch === null || paypalTouch === void 0 ? void 0 : paypalTouch.library) === null || _e === void 0 ? void 0 : _e.Buttons)) {
+            return false;
+        }
+        const buttons = paypalTouch.library.Buttons.bind(paypalTouch.library);
+        paypalTouch.library.Buttons = (o) => buttons(Object.assign(Object.assign({}, o), { onClick: (d, a) => (this._form.dispatchIntentSubmit.bind(this._form),
+                o.onClick && o.onClick(d, a)) }));
+        paypalTouch.unloadButton && paypalTouch.unloadButton();
+        paypalTouch.loadButton && paypalTouch.loadButton();
+        return true;
+    }
+    addStripeDigitalWalletListener() {
+        var _a, _b, _c, _d, _e, _f;
+        return !!((_f = (_e = (_d = (_c = (_b = (_a = window.EngagingNetworks) === null || _a === void 0 ? void 0 : _a.require) === null || _b === void 0 ? void 0 : _b._defined) === null || _c === void 0 ? void 0 : _c.enStripeButtons) === null || _d === void 0 ? void 0 : _d.stripeButtons) === null || _e === void 0 ? void 0 : _e.paymentRequest) === null || _f === void 0 ? void 0 : _f.on("paymentmethod", this._form.dispatchIntentSubmit.bind(this._form)));
+    }
+    addDAFListener() {
+        var _a;
+        return !!((_a = document
+            .getElementById("chariot-button")) === null || _a === void 0 ? void 0 : _a.addEventListener("click", this._form.dispatchIntentSubmit.bind(this._form)));
     }
 }

--- a/packages/scripts/dist/digital-wallets.js
+++ b/packages/scripts/dist/digital-wallets.js
@@ -178,12 +178,10 @@ export class DigitalWallets {
             return false;
         }
         const buttons = paypalTouch.library.Buttons.bind(paypalTouch.library);
-        // setTimeout(() => {
         paypalTouch.library.Buttons = (o) => buttons(Object.assign(Object.assign({}, o), { onClick: (d, a) => (this._form.dispatchIntentSubmit(),
                 o.onClick && o.onClick(d, a)) }));
         paypalTouch.unloadButton && paypalTouch.unloadButton();
         paypalTouch.loadButton && paypalTouch.loadButton();
-        // }, 750);
         return true;
     }
     addStripeDigitalWalletListener() {

--- a/packages/scripts/dist/events/en-form.d.ts
+++ b/packages/scripts/dist/events/en-form.d.ts
@@ -35,13 +35,13 @@ export declare class EnForm {
      */
     get onSubmit(): import("strongly-typed-events").ISignal;
     /**
-   * onError is dispatched using window.enOnError, which is called by Engaging Networks' JavaScript when a server-side validation error occurs on form submission.
-   * This allows you to listen for validation errors and respond accordingly, such as displaying custom error messages or triggering analytics events.
-   */
-    get onError(): import("strongly-typed-events").ISignal;
-    /**
      * onValidate is dispatched using window.enOnValidate, which is called by Engaging Networks' JavaScript
      * when the form is being validated, before submission. This only occurs after ENgrid's client-side validation has passed, but before server-side validation.
      */
     get onValidate(): import("strongly-typed-events").ISignal;
+    /**
+     * onError is dispatched using window.enOnError, which is called by Engaging Networks' JavaScript when a server-side validation error occurs on form submission.
+     * This allows you to listen for validation errors and respond accordingly, such as displaying custom error messages or triggering analytics events.
+     */
+    get onError(): import("strongly-typed-events").ISignal;
 }

--- a/packages/scripts/dist/events/en-form.d.ts
+++ b/packages/scripts/dist/events/en-form.d.ts
@@ -1,5 +1,6 @@
 export declare class EnForm {
     private logger;
+    private _onIntentSubmit;
     private _onSubmit;
     private _onValidate;
     private _onError;
@@ -10,11 +11,37 @@ export declare class EnForm {
     private static instance;
     private constructor();
     static getInstance(): EnForm;
+    dispatchIntentSubmit(): void;
     dispatchSubmit(): void;
     dispatchValidate(): void;
     dispatchError(): void;
     submitForm(): void;
+    /**
+     * onIntentSubmit is dispatched when a submit button is clicked,
+     * or a digital wallet submission is initiated,
+     * but before server-side validation or the actual submit event.
+     * This allows you to run code at the moment the user intends to submit,
+     * such as triggering data formatting, analytics events, or other pre-submit actions.
+     * Actions that rely on fully processed form data or validation results should use the onSubmit event instead.
+     * Note: onSubmit will also dispatch onIntentSubmit, so do not repeat actions in both events.
+     */
+    get onIntentSubmit(): import("strongly-typed-events").ISignal;
+    /**
+     * onSubmit is dispatched when the form is submitted, after validation has passed.
+     * This is the main event to listen to for form submissions, as it indicates that the user has successfully submitted the form and all validation checks have been passed.
+     * This event uses window.enOnSubmit, which is called by Engaging Networks' JavaScript when the form is submitted.
+     * At the time of writing, enOnSubmit does not trigger when a user submits via a digital wallet, use onIntentSubmit to listen for those submission attempts.
+     * Note: onSubmit will also dispatch onIntentSubmit, so do not repeat actions in both events.
+     */
     get onSubmit(): import("strongly-typed-events").ISignal;
+    /**
+     * onValidate is dispatched using window.enOnValidate, which is called by Engaging Networks' JavaScript
+     * when the form is being validated, before submission. This only occurs after ENgrid's client-side validation has passed, but before server-side validation.
+     */
     get onError(): import("strongly-typed-events").ISignal;
+    /**
+     * onError is dispatched using window.enOnError, which is called by Engaging Networks' JavaScript when a server-side validation error occurs on form submission.
+     * This allows you to listen for validation errors and respond accordingly, such as displaying custom error messages or triggering analytics events.
+     */
     get onValidate(): import("strongly-typed-events").ISignal;
 }

--- a/packages/scripts/dist/events/en-form.d.ts
+++ b/packages/scripts/dist/events/en-form.d.ts
@@ -35,13 +35,13 @@ export declare class EnForm {
      */
     get onSubmit(): import("strongly-typed-events").ISignal;
     /**
-     * onValidate is dispatched using window.enOnValidate, which is called by Engaging Networks' JavaScript
-     * when the form is being validated, before submission. This only occurs after ENgrid's client-side validation has passed, but before server-side validation.
-     */
+   * onError is dispatched using window.enOnError, which is called by Engaging Networks' JavaScript when a server-side validation error occurs on form submission.
+   * This allows you to listen for validation errors and respond accordingly, such as displaying custom error messages or triggering analytics events.
+   */
     get onError(): import("strongly-typed-events").ISignal;
     /**
-     * onError is dispatched using window.enOnError, which is called by Engaging Networks' JavaScript when a server-side validation error occurs on form submission.
-     * This allows you to listen for validation errors and respond accordingly, such as displaying custom error messages or triggering analytics events.
+     * onValidate is dispatched using window.enOnValidate, which is called by Engaging Networks' JavaScript
+     * when the form is being validated, before submission. This only occurs after ENgrid's client-side validation has passed, but before server-side validation.
      */
     get onValidate(): import("strongly-typed-events").ISignal;
 }

--- a/packages/scripts/dist/events/en-form.js
+++ b/packages/scripts/dist/events/en-form.js
@@ -68,15 +68,15 @@ export class EnForm {
         return this._onSubmit.asEvent();
     }
     /**
-     * onValidate is dispatched using window.enOnValidate, which is called by Engaging Networks' JavaScript
-     * when the form is being validated, before submission. This only occurs after ENgrid's client-side validation has passed, but before server-side validation.
-     */
+   * onError is dispatched using window.enOnError, which is called by Engaging Networks' JavaScript when a server-side validation error occurs on form submission.
+   * This allows you to listen for validation errors and respond accordingly, such as displaying custom error messages or triggering analytics events.
+   */
     get onError() {
         return this._onError.asEvent();
     }
     /**
-     * onError is dispatched using window.enOnError, which is called by Engaging Networks' JavaScript when a server-side validation error occurs on form submission.
-     * This allows you to listen for validation errors and respond accordingly, such as displaying custom error messages or triggering analytics events.
+     * onValidate is dispatched using window.enOnValidate, which is called by Engaging Networks' JavaScript
+     * when the form is being validated, before submission. This only occurs after ENgrid's client-side validation has passed, but before server-side validation.
      */
     get onValidate() {
         return this._onValidate.asEvent();

--- a/packages/scripts/dist/events/en-form.js
+++ b/packages/scripts/dist/events/en-form.js
@@ -3,6 +3,7 @@ import { EngridLogger } from "..";
 export class EnForm {
     constructor() {
         this.logger = new EngridLogger("EnForm");
+        this._onIntentSubmit = new SignalDispatcher();
         this._onSubmit = new SignalDispatcher();
         this._onValidate = new SignalDispatcher();
         this._onError = new SignalDispatcher();
@@ -16,6 +17,10 @@ export class EnForm {
             EnForm.instance = new EnForm();
         }
         return EnForm.instance;
+    }
+    dispatchIntentSubmit() {
+        this._onIntentSubmit.dispatch();
+        this.logger.log("dispatchIntentSubmit");
     }
     dispatchSubmit() {
         this._onSubmit.dispatch();
@@ -40,12 +45,39 @@ export class EnForm {
             this.logger.log("submitForm");
         }
     }
+    /**
+     * onIntentSubmit is dispatched when a submit button is clicked,
+     * or a digital wallet submission is initiated,
+     * but before server-side validation or the actual submit event.
+     * This allows you to run code at the moment the user intends to submit,
+     * such as triggering data formatting, analytics events, or other pre-submit actions.
+     * Actions that rely on fully processed form data or validation results should use the onSubmit event instead.
+     * Note: onSubmit will also dispatch onIntentSubmit, so do not repeat actions in both events.
+     */
+    get onIntentSubmit() {
+        return this._onIntentSubmit.asEvent();
+    }
+    /**
+     * onSubmit is dispatched when the form is submitted, after validation has passed.
+     * This is the main event to listen to for form submissions, as it indicates that the user has successfully submitted the form and all validation checks have been passed.
+     * This event uses window.enOnSubmit, which is called by Engaging Networks' JavaScript when the form is submitted.
+     * At the time of writing, enOnSubmit does not trigger when a user submits via a digital wallet, use onIntentSubmit to listen for those submission attempts.
+     * Note: onSubmit will also dispatch onIntentSubmit, so do not repeat actions in both events.
+     */
     get onSubmit() {
         return this._onSubmit.asEvent();
     }
+    /**
+     * onValidate is dispatched using window.enOnValidate, which is called by Engaging Networks' JavaScript
+     * when the form is being validated, before submission. This only occurs after ENgrid's client-side validation has passed, but before server-side validation.
+     */
     get onError() {
         return this._onError.asEvent();
     }
+    /**
+     * onError is dispatched using window.enOnError, which is called by Engaging Networks' JavaScript when a server-side validation error occurs on form submission.
+     * This allows you to listen for validation errors and respond accordingly, such as displaying custom error messages or triggering analytics events.
+     */
     get onValidate() {
         return this._onValidate.asEvent();
     }

--- a/packages/scripts/dist/events/en-form.js
+++ b/packages/scripts/dist/events/en-form.js
@@ -68,17 +68,17 @@ export class EnForm {
         return this._onSubmit.asEvent();
     }
     /**
-   * onError is dispatched using window.enOnError, which is called by Engaging Networks' JavaScript when a server-side validation error occurs on form submission.
-   * This allows you to listen for validation errors and respond accordingly, such as displaying custom error messages or triggering analytics events.
-   */
-    get onError() {
-        return this._onError.asEvent();
-    }
-    /**
      * onValidate is dispatched using window.enOnValidate, which is called by Engaging Networks' JavaScript
      * when the form is being validated, before submission. This only occurs after ENgrid's client-side validation has passed, but before server-side validation.
      */
     get onValidate() {
         return this._onValidate.asEvent();
+    }
+    /**
+     * onError is dispatched using window.enOnError, which is called by Engaging Networks' JavaScript when a server-side validation error occurs on form submission.
+     * This allows you to listen for validation errors and respond accordingly, such as displaying custom error messages or triggering analytics events.
+     */
+    get onError() {
+        return this._onError.asEvent();
     }
 }

--- a/packages/scripts/dist/interfaces/options.d.ts
+++ b/packages/scripts/dist/interfaces/options.d.ts
@@ -178,6 +178,7 @@ export interface Options {
     };
     onLoad?: () => void;
     onResize?: () => void;
+    onIntentSubmit?: () => void;
     onSubmit?: () => void;
     onError?: () => void;
     onValidate?: () => void;

--- a/packages/scripts/src/app.ts
+++ b/packages/scripts/src/app.ts
@@ -226,6 +226,7 @@ export class App extends ENGrid {
     });
 
     // Client onSubmit and onError functions
+    this._form.onIntentSubmit.subscribe(() => this.onIntentSubmit());
     this._form.onSubmit.subscribe(() => this.onSubmit());
     this._form.onError.subscribe(() => this.onError());
     this._form.onValidate.subscribe(() => this.onValidate());
@@ -253,6 +254,7 @@ export class App extends ENGrid {
     window.enOnSubmit = () => {
       this._form.submit = true;
       this._form.submitPromise = false;
+      this._form.dispatchIntentSubmit();
       this._form.dispatchSubmit();
       ENGrid.watchForError(ENGrid.enableSubmit);
       if (!this._form.submit) return false;
@@ -525,6 +527,13 @@ export class App extends ENGrid {
     if (this.options.onValidate) {
       this.logger.log("Client onValidate Triggered");
       this.options.onValidate();
+    }
+  }
+
+  private onIntentSubmit() {
+    if (this.options.onIntentSubmit) {
+      this.logger.log("Client onIntentSubmit Triggered");
+      this.options.onIntentSubmit();
     }
   }
 

--- a/packages/scripts/src/digital-wallets.ts
+++ b/packages/scripts/src/digital-wallets.ts
@@ -229,18 +229,16 @@ export class DigitalWallets {
       return false;
     }
     const buttons = paypalTouch.library.Buttons.bind(paypalTouch.library);
-    setTimeout(() => {
-      paypalTouch.library.Buttons = (o: any) =>
-        buttons({
-          ...o,
-          onClick: (d: any, a: any) => (
-            this._form.dispatchIntentSubmit(),
-            o.onClick && o.onClick(d, a)
-          ),
-        });
-      paypalTouch.unloadButton && paypalTouch.unloadButton();
-      paypalTouch.loadButton && paypalTouch.loadButton();
-    }, 750);
+    paypalTouch.library.Buttons = (o: any) =>
+      buttons({
+        ...o,
+        onClick: (d: any, a: any) => (
+          this._form.dispatchIntentSubmit(),
+          o.onClick && o.onClick(d, a)
+        ),
+      });
+    paypalTouch.unloadButton && paypalTouch.unloadButton();
+    paypalTouch.loadButton && paypalTouch.loadButton();
     return true;
   }
 

--- a/packages/scripts/src/digital-wallets.ts
+++ b/packages/scripts/src/digital-wallets.ts
@@ -1,6 +1,16 @@
 import { ENGrid } from "./engrid";
+import { EnForm } from "./events";
+import { EngridLogger } from "./logger";
 
 export class DigitalWallets {
+  private logger: EngridLogger = new EngridLogger(
+    "DigitalWallets",
+    "#fff",
+    "#333",
+    "👛"
+  );
+  private _form: EnForm = EnForm.getInstance();
+
   constructor() {
     //digital wallets not enabled.
     if (!document.getElementById("en__digitalWallet")) {
@@ -10,6 +20,9 @@ export class DigitalWallets {
       ENGrid.setBodyData("payment-type-option-paypal-one-touch", "false");
       ENGrid.setBodyData("payment-type-option-venmo", "false");
       ENGrid.setBodyData("payment-type-option-daf", "false");
+      this.logger.log(
+        "No digital wallet container found, skipping digital wallet setup."
+      );
       return;
     }
 
@@ -112,6 +125,7 @@ export class DigitalWallets {
   }
 
   private addStripeDigitalWallets() {
+    this.logger.log("Stripe Digital Wallets detected");
     this.addOptionToPaymentTypeField(
       "stripedigitalwallet",
       "GooglePay / ApplePay"
@@ -128,17 +142,28 @@ export class DigitalWallets {
     ENGrid.setBodyData("payment-type-option-apple-pay", "true");
     ENGrid.setBodyData("payment-type-option-google-pay", "true");
     ENGrid.setBodyData("payment-type-option-stripedigitalwallet", "true");
+    this.addStripeDigitalWalletListener()
+      ? this.logger.log("Stripe Digital Wallet listener added successfully")
+      : this.logger.log("Failed to add Stripe Digital Wallet listener");
   }
 
   private addPaypalTouchDigitalWallets() {
+    this.logger.log("Paypal Touch Digital Wallets detected");
     this.addOptionToPaymentTypeField("paypaltouch", "Paypal / Venmo");
     ENGrid.setBodyData("payment-type-option-paypal-one-touch", "true");
     ENGrid.setBodyData("payment-type-option-venmo", "true");
+    this.addPaypalOneTouchListener()
+      ? this.logger.log("Paypal Touch listener added successfully")
+      : this.logger.log("Failed to add Paypal Touch listener");
   }
 
   private addDAF() {
+    this.logger.log("Donor Advised Fund Digital Wallets detected");
     this.addOptionToPaymentTypeField("daf", "Donor Advised Fund");
     ENGrid.setBodyData("payment-type-option-daf", "true");
+    this.addDAFListener()
+      ? this.logger.log("DAF listener added successfully")
+      : this.logger.log("Failed to add DAF listener");
   }
 
   private addOptionToPaymentTypeField(value: string, label: string) {
@@ -185,13 +210,50 @@ export class DigitalWallets {
           } else if (walletType === "daf") {
             this.addDAF();
           }
-          //Disconnect observer to prevent multiple additions
+          //Disconnect observer and break loop to prevent multiple additions
           observer.disconnect();
+          break;
         }
       }
     };
 
     const observer = new MutationObserver(callback);
     observer.observe(node, { childList: true, subtree: true });
+  }
+
+  private addPaypalOneTouchListener(): boolean {
+    const paypalTouch =
+      window.EngagingNetworks?.require?._defined?.enPaypalTouch?.paypalTouch;
+    if (!paypalTouch?.library?.Buttons) {
+      return false;
+    }
+    const buttons = paypalTouch.library.Buttons.bind(paypalTouch.library);
+    paypalTouch.library.Buttons = (o: any) =>
+      buttons({
+        ...o,
+        onClick: (d: any, a: any) => (
+          this._form.dispatchIntentSubmit.bind(this._form),
+          o.onClick && o.onClick(d, a)
+        ),
+      });
+    paypalTouch.unloadButton && paypalTouch.unloadButton();
+    paypalTouch.loadButton && paypalTouch.loadButton();
+    return true;
+  }
+
+  private addStripeDigitalWalletListener(): boolean {
+    return !!window.EngagingNetworks?.require?._defined?.enStripeButtons?.stripeButtons?.paymentRequest?.on(
+      "paymentmethod",
+      this._form.dispatchIntentSubmit.bind(this._form)
+    );
+  }
+
+  private addDAFListener(): boolean {
+    return !!document
+      .getElementById("chariot-button")
+      ?.addEventListener(
+        "click",
+        this._form.dispatchIntentSubmit.bind(this._form)
+      );
   }
 }

--- a/packages/scripts/src/digital-wallets.ts
+++ b/packages/scripts/src/digital-wallets.ts
@@ -158,7 +158,7 @@ export class DigitalWallets {
   }
 
   private addDAF() {
-    this.logger.log("Donor Advised Fund Digital Wallets detected");
+    this.logger.log("DAF Digital Wallet detected");
     this.addOptionToPaymentTypeField("daf", "Donor Advised Fund");
     ENGrid.setBodyData("payment-type-option-daf", "true");
     this.addDAFListener()
@@ -225,19 +225,22 @@ export class DigitalWallets {
     const paypalTouch =
       window.EngagingNetworks?.require?._defined?.enPaypalTouch?.paypalTouch;
     if (!paypalTouch?.library?.Buttons) {
+      this.logger.log("Paypal Touch library not found, cannot add listener");
       return false;
     }
     const buttons = paypalTouch.library.Buttons.bind(paypalTouch.library);
-    paypalTouch.library.Buttons = (o: any) =>
-      buttons({
-        ...o,
-        onClick: (d: any, a: any) => (
-          this._form.dispatchIntentSubmit.bind(this._form),
-          o.onClick && o.onClick(d, a)
-        ),
-      });
-    paypalTouch.unloadButton && paypalTouch.unloadButton();
-    paypalTouch.loadButton && paypalTouch.loadButton();
+    setTimeout(() => {
+      paypalTouch.library.Buttons = (o: any) =>
+        buttons({
+          ...o,
+          onClick: (d: any, a: any) => (
+            this._form.dispatchIntentSubmit(),
+            o.onClick && o.onClick(d, a)
+          ),
+        });
+      paypalTouch.unloadButton && paypalTouch.unloadButton();
+      paypalTouch.loadButton && paypalTouch.loadButton();
+    }, 750);
     return true;
   }
 
@@ -249,11 +252,11 @@ export class DigitalWallets {
   }
 
   private addDAFListener(): boolean {
-    return !!document
-      .getElementById("chariot-button")
-      ?.addEventListener(
-        "click",
-        this._form.dispatchIntentSubmit.bind(this._form)
-      );
+    const chariotButton = document.getElementById("chariot-button");
+    chariotButton?.addEventListener(
+      "click",
+      this._form.dispatchIntentSubmit.bind(this._form)
+    );
+    return !!chariotButton;
   }
 }

--- a/packages/scripts/src/events/en-form.ts
+++ b/packages/scripts/src/events/en-form.ts
@@ -82,18 +82,18 @@ export class EnForm {
   }
 
   /**
- * onError is dispatched using window.enOnError, which is called by Engaging Networks' JavaScript when a server-side validation error occurs on form submission.
- * This allows you to listen for validation errors and respond accordingly, such as displaying custom error messages or triggering analytics events.
- */
-  public get onError() {
-    return this._onError.asEvent();
-  }
-
-  /**
    * onValidate is dispatched using window.enOnValidate, which is called by Engaging Networks' JavaScript
    * when the form is being validated, before submission. This only occurs after ENgrid's client-side validation has passed, but before server-side validation.
    */
   public get onValidate() {
     return this._onValidate.asEvent();
+  }
+
+  /**
+   * onError is dispatched using window.enOnError, which is called by Engaging Networks' JavaScript when a server-side validation error occurs on form submission.
+   * This allows you to listen for validation errors and respond accordingly, such as displaying custom error messages or triggering analytics events.
+   */
+  public get onError() {
+    return this._onError.asEvent();
   }
 }

--- a/packages/scripts/src/events/en-form.ts
+++ b/packages/scripts/src/events/en-form.ts
@@ -14,7 +14,7 @@ export class EnForm {
 
   private static instance: EnForm;
 
-  private constructor() {}
+  private constructor() { }
 
   public static getInstance(): EnForm {
     if (!EnForm.instance) {
@@ -82,16 +82,16 @@ export class EnForm {
   }
 
   /**
-   * onValidate is dispatched using window.enOnValidate, which is called by Engaging Networks' JavaScript
-   * when the form is being validated, before submission. This only occurs after ENgrid's client-side validation has passed, but before server-side validation.
-   */
+ * onError is dispatched using window.enOnError, which is called by Engaging Networks' JavaScript when a server-side validation error occurs on form submission.
+ * This allows you to listen for validation errors and respond accordingly, such as displaying custom error messages or triggering analytics events.
+ */
   public get onError() {
     return this._onError.asEvent();
   }
 
   /**
-   * onError is dispatched using window.enOnError, which is called by Engaging Networks' JavaScript when a server-side validation error occurs on form submission.
-   * This allows you to listen for validation errors and respond accordingly, such as displaying custom error messages or triggering analytics events.
+   * onValidate is dispatched using window.enOnValidate, which is called by Engaging Networks' JavaScript
+   * when the form is being validated, before submission. This only occurs after ENgrid's client-side validation has passed, but before server-side validation.
    */
   public get onValidate() {
     return this._onValidate.asEvent();

--- a/packages/scripts/src/events/en-form.ts
+++ b/packages/scripts/src/events/en-form.ts
@@ -3,6 +3,7 @@ import { EngridLogger } from "..";
 
 export class EnForm {
   private logger: EngridLogger = new EngridLogger("EnForm");
+  private _onIntentSubmit = new SignalDispatcher();
   private _onSubmit = new SignalDispatcher();
   private _onValidate = new SignalDispatcher();
   private _onError = new SignalDispatcher();
@@ -21,6 +22,11 @@ export class EnForm {
     }
 
     return EnForm.instance;
+  }
+
+  public dispatchIntentSubmit() {
+    this._onIntentSubmit.dispatch();
+    this.logger.log("dispatchIntentSubmit");
   }
 
   public dispatchSubmit() {
@@ -51,14 +57,42 @@ export class EnForm {
     }
   }
 
+  /**
+   * onIntentSubmit is dispatched when a submit button is clicked,
+   * or a digital wallet submission is initiated,
+   * but before server-side validation or the actual submit event.
+   * This allows you to run code at the moment the user intends to submit,
+   * such as triggering data formatting, analytics events, or other pre-submit actions.
+   * Actions that rely on fully processed form data or validation results should use the onSubmit event instead.
+   * Note: onSubmit will also dispatch onIntentSubmit, so do not repeat actions in both events.
+   */
+  public get onIntentSubmit() {
+    return this._onIntentSubmit.asEvent();
+  }
+
+  /**
+   * onSubmit is dispatched when the form is submitted, after validation has passed.
+   * This is the main event to listen to for form submissions, as it indicates that the user has successfully submitted the form and all validation checks have been passed.
+   * This event uses window.enOnSubmit, which is called by Engaging Networks' JavaScript when the form is submitted.
+   * At the time of writing, enOnSubmit does not trigger when a user submits via a digital wallet, use onIntentSubmit to listen for those submission attempts.
+   * Note: onSubmit will also dispatch onIntentSubmit, so do not repeat actions in both events.
+   */
   public get onSubmit() {
     return this._onSubmit.asEvent();
   }
 
+  /**
+   * onValidate is dispatched using window.enOnValidate, which is called by Engaging Networks' JavaScript
+   * when the form is being validated, before submission. This only occurs after ENgrid's client-side validation has passed, but before server-side validation.
+   */
   public get onError() {
     return this._onError.asEvent();
   }
 
+  /**
+   * onError is dispatched using window.enOnError, which is called by Engaging Networks' JavaScript when a server-side validation error occurs on form submission.
+   * This allows you to listen for validation errors and respond accordingly, such as displaying custom error messages or triggering analytics events.
+   */
   public get onValidate() {
     return this._onValidate.asEvent();
   }

--- a/packages/scripts/src/interfaces/options.ts
+++ b/packages/scripts/src/interfaces/options.ts
@@ -61,7 +61,19 @@ export interface Options {
     | false
     | {
         cid?: string; // Client ID
-        page_types?: ("DONATION" | "ECARD" | "SURVEY" | "EMAILTOTARGET" | "ADVOCACY" | "SUBSCRIBEFORM" | "EVENT" | "SUPPORTERHUB" | "UNSUBSCRIBE" | "TWEETPAGE" | "UNKNOWN")[]; // Page Types to enable TidyContact on, if left blank will run on all page types
+        page_types?: (
+          | "DONATION"
+          | "ECARD"
+          | "SURVEY"
+          | "EMAILTOTARGET"
+          | "ADVOCACY"
+          | "SUBSCRIBEFORM"
+          | "EVENT"
+          | "SUPPORTERHUB"
+          | "UNSUBSCRIBE"
+          | "TWEETPAGE"
+          | "UNKNOWN"
+        )[]; // Page Types to enable TidyContact on, if left blank will run on all page types
         record_field?: string; // TidyContact Record
         date_field?: string; // TidyContact Date
         status_field?: string; // TidyContact Status
@@ -188,6 +200,7 @@ export interface Options {
       };
   onLoad?: () => void;
   onResize?: () => void;
+  onIntentSubmit?: () => void;
   onSubmit?: () => void;
   onError?: () => void;
   onValidate?: () => void;


### PR DESCRIPTION
# Intent Submit

Working task: 

This update adds a new `IntentSubmit` event that dispatches when a user submits the form through the standard submit button and through digital wallets (which presently do not fire `window.enOnSubmit` on Engaging Networks). Since a user can back out of a digital wallet payment, this is simply an event of when the user *intends* to submit the form, and fires after client side validation but before server side validation. Thusly, it's important that nothing that relies on final transactions being completed be called when `IntentSubmit` is dispatched. Since `IntentSubmit` is also dispatched during `window.enOnSubmit` both it and the `Submit` event can be fired in the event of a standard form submission.

The only part I feel is a bit shoddy, but does work, is that there is a 750ms timeout to apply the listener to paypal touch buttons, attempting to apply the listener at execution results in an error from the paypal js sdk.


## Changelog


Updates to the `DigitalWallets` module
* Logger for reporting availability of payment types
* Submission listeners for Stripe Digital Wallets, PayPal One Touch, and DAN that fire "IntentSubmit" on EnForm


Updates to `EnForm` (and `App`)
* New `IntentSubmit` event, which fires from digital wallet submissions, and as part of the standard `Submit` event.
    * `this._form.onIntentSubmit.subscribe(...)`
* Inline documentation for each type of event
* `onIntentSubmit` option which can be set at the client theme level to run across all pages similar to `onSubmit` option.


## Use Cases


Ideally, the TidyContact module could be updated to use this new event to detect when to call the API in the event of digital wallets. This would also have a use in Oceana's MobileCommons integration, and RAN's E-card Recipient module.

## Testing Instructions

Testing Page: https://act.ran.org/page/96242/donate/1?debug=log (Operating on client theme branch `ecard-intent-submit`). Test Stripe / Test DAF / **LIVE** PayPal+Venmo

Ideal testing page as it is configured for all 3 of the digital wallet methods supported by this change. Use a browser that supports Google Pay or Apple Pay

**Page Load**
0. Ensure you have "Preserve Logs" checked in your debug console.
1. Check for `👛 [ENgrid DigitalWallets]` in the logs, there should be a pair of logs for detecting then adding listeners for Paypal Touch, Donor Advised Fund, and Stripe Digital Wallets (https://cln.sh/p0TRtv8B)
2. Quick fill your details, client side validation must pass
3. Select DAF on the giveBySelect
4. Click the DAF checkout button (Payment does NOT need to be processed)
5. Check for `🍏 [ENgrid App] Client onIntentSubmit Triggered`, `Starter Theme Intent to Submit`, and `⚫ [ENgrid EnForm] dispatchIntentSubmit` in logs
6. Close the DAF window
7. Select Paypal or Venmo on the giveBySelect
8. Click the Paypal or Venmo checkout buttons
9. Check for `🍏 [ENgrid App] Client onIntentSubmit Triggered`, `Starter Theme Intent to Submit`, and `⚫ [ENgrid EnForm] dispatchIntentSubmit` in logs
10. Close the PayPal or Venmo checkout window (Payment does NOT need to be processed)
11. Click Google Pay / Apple Pay on the giveBySelect
12. Click the Apple Pay (Safari), GPay (Google Chrome) checkout button
13. Complete the checkout flow
14. Check for `🍏 [ENgrid App] Client onIntentSubmit Triggered`, `Starter Theme Intent to Submit`, and `⚫ [ENgrid EnForm] dispatchIntentSubmit` in logs. Will appear just before page redirection, so preserve logs will help in seeing these.