### PR TITLE
Add duplicate submission prevention to Supporter Hub

### DIFF
--- a/packages/scripts/dist/supporter-hub.d.ts
+++ b/packages/scripts/dist/supporter-hub.d.ts
@@ -6,4 +6,5 @@ export declare class SupporterHub {
     watch(): void;
     creditCardUpdate(overlay: HTMLDivElement): void;
     amountLabelUpdate(overlay: HTMLDivElement): void;
+    private preventDuplicateSubmits;
 }

--- a/packages/scripts/dist/supporter-hub.js
+++ b/packages/scripts/dist/supporter-hub.js
@@ -8,6 +8,7 @@ export class SupporterHub {
             return;
         this.logger.log("Enabled");
         this.watch();
+        this.preventDuplicateSubmits();
     }
     shoudRun() {
         return ("pageJson" in window &&
@@ -71,5 +72,20 @@ export class SupporterHub {
                 });
             }
         }, 300);
+    }
+    // The supporter hub does not properly handle or prevent duplicate submits, so we add a listener to prevent this.
+    preventDuplicateSubmits() {
+        document.addEventListener("click", (e) => {
+            const btn = e.target.closest(".en__submit button");
+            if (!btn)
+                return;
+            if (btn.dataset.busy) {
+                e.stopImmediatePropagation();
+                e.preventDefault();
+                return;
+            }
+            btn.dataset.busy = "true";
+            setTimeout(() => delete btn.dataset.busy, 10000);
+        }, true);
     }
 }

--- a/packages/scripts/src/supporter-hub.ts
+++ b/packages/scripts/src/supporter-hub.ts
@@ -14,6 +14,7 @@ export class SupporterHub {
     if (!this.shoudRun()) return;
     this.logger.log("Enabled");
     this.watch();
+    this.preventDuplicateSubmits();
   }
   shoudRun() {
     return (
@@ -88,5 +89,26 @@ export class SupporterHub {
           });
       }
     }, 300);
+  }
+
+  // The supporter hub does not properly handle or prevent duplicate submits, so we add a listener to prevent this.
+  private preventDuplicateSubmits() {
+    document.addEventListener(
+      "click",
+      (e: MouseEvent) => {
+        const btn = (e.target as HTMLElement).closest(
+          ".en__submit button"
+        ) as HTMLButtonElement;
+        if (!btn) return;
+        if (btn.dataset.busy) {
+          e.stopImmediatePropagation();
+          e.preventDefault();
+          return;
+        }
+        btn.dataset.busy = "true";
+        setTimeout(() => delete btn.dataset.busy, 10000);
+      },
+      true
+    );
   }
 }


### PR DESCRIPTION
Adds a handler to prevent duplicate submissions in the supporter hub that can create duplicate recurring subscriptions.

EN's code does not prevent duplicate submissions when the Enter key on your keyboard is pressed repeatedly during form submission. They hide and disable the submit button - but their code handles the request through a click handler that sends an ajax request and the browser synthetically calls that click handler when the form is submitted by enter key.

Steps to reproduce:

- Have an active recurring subscription
- Log into the supporter hub and open the "manage my recurring gift" tool
- Fill out the form to update your gift - whether it's a new card number or a change to the amount - and submit the form by pressing the Enter key on your keyboard. Spam the Enter key repeatedly during form submission.
- Check your supporter record and you will see duplicate recurring subscriptions equal to the number of times you pressed the enter button.

This solution prevents their click handler running by intercepting the request (with capture: true on our handler, so it runs first) and adding a data property to prevent submissions more than once every 10 seconds. I think it's the best we can do on our side.

You can test it on this hub using a client theme branch: https://protect.worldwildlife.org/page/92899/hub/2?assets=fix-hub

When using that branch, there should not be duplicate recurring subscriptions created.

I've reported the issue to EN in ticket SUP-20769.