### PR TITLE
Update EventTickets with waitlist links

### DIFF
--- a/packages/scripts/dist/event-tickets.d.ts
+++ b/packages/scripts/dist/event-tickets.d.ts
@@ -1,3 +1,5 @@
 export declare class EventTickets {
     constructor();
+    private showWaitlistLinkIfApplicable;
+    private formatTicketAmountsAsCurrency;
 }

--- a/packages/scripts/dist/event-tickets.js
+++ b/packages/scripts/dist/event-tickets.js
@@ -1,7 +1,23 @@
 export class EventTickets {
     constructor() {
-        // --------------------------------------------
-        // Format ticket amounts as currency.
+        this.formatTicketAmountsAsCurrency();
+        this.showWaitlistLinkIfApplicable();
+    }
+    showWaitlistLinkIfApplicable() {
+        const waitlistLink = document.querySelector(".waitlist-link a");
+        if (!waitlistLink) {
+            return;
+        }
+        document.querySelectorAll('.en__ticket').forEach((ticket) => {
+            const soldOutMessage = ticket.querySelector(".en__ticket__soldout");
+            if (soldOutMessage) {
+                const waitlistClone = waitlistLink.cloneNode(true);
+                waitlistClone.className = "waitlist-link";
+                soldOutMessage.insertAdjacentElement("afterend", waitlistClone);
+            }
+        });
+    }
+    formatTicketAmountsAsCurrency() {
         const ticketCostElements = document.getElementsByClassName("en__ticket__field--cost");
         const ticketCurrencyElements = document.getElementsByClassName("en__ticket__currency");
         for (const ticketCurrencyElement of ticketCurrencyElements) {

--- a/packages/scripts/src/event-tickets.ts
+++ b/packages/scripts/src/event-tickets.ts
@@ -1,8 +1,25 @@
 export class EventTickets {
   constructor() {
-    // --------------------------------------------
-    // Format ticket amounts as currency.
+    this.formatTicketAmountsAsCurrency();
+    this.showWaitlistLinkIfApplicable();
+  }
 
+  private showWaitlistLinkIfApplicable() {
+    const waitlistLink = document.querySelector(".waitlist-link a");
+    if (!waitlistLink) {
+      return;
+    }
+    document.querySelectorAll('.en__ticket').forEach((ticket) => {
+      const soldOutMessage = ticket.querySelector(".en__ticket__soldout");
+      if (soldOutMessage) {
+        const waitlistClone = waitlistLink.cloneNode(true) as HTMLElement;
+        waitlistClone.className = "waitlist-link";
+        soldOutMessage.insertAdjacentElement("afterend", waitlistClone);
+      }
+    });
+  }
+
+  private formatTicketAmountsAsCurrency() {
     const ticketCostElements = document.getElementsByClassName(
       "en__ticket__field--cost"
     );


### PR DESCRIPTION
Adds the functionality to show a waitlist link when an event's tickets are sold out

This is done by taking the first `a` tag found within an element with the `waitlist-link` class. Optimally, this means creating a text block and setting the custom class name to `waitlist-link hide` - To create an easily editable link and hide the markdown.

A test page has been created here on the sandbox (CA) account: https://ca-sandbox.engagingnetworks.io/page/191759/event/1

Result: https://cln.sh/brX5mzSr

The sold out ticket has the waitlist link below, the in stock ticket does not.