### PR TITLE
feat: add DisableLiveValidation option to min-max-amount

### DIFF
--- a/packages/scripts/dist/interfaces/options.d.ts
+++ b/packages/scripts/dist/interfaces/options.d.ts
@@ -16,6 +16,7 @@ export interface Options {
     MinAmountMessage?: string;
     MaxAmountMessage?: string;
     UseAmountValidatorFromEN?: boolean;
+    DisableLiveValidation?: boolean;
     SkipToMainContentLink?: boolean;
     SrcDefer?: boolean;
     SuppressPurchaseEcard?: boolean;

--- a/packages/scripts/dist/min-max-amount.d.ts
+++ b/packages/scripts/dist/min-max-amount.d.ts
@@ -6,6 +6,7 @@ export declare class MinMaxAmount {
     private maxAmount;
     private minAmountMessage;
     private maxAmountMessage;
+    private disableLiveValidation;
     private enAmountValidator;
     private logger;
     constructor();

--- a/packages/scripts/dist/min-max-amount.js
+++ b/packages/scripts/dist/min-max-amount.js
@@ -40,10 +40,12 @@ export class MinMaxAmount {
             }
             this._form.validate = false;
             if (this.disableLiveValidation) {
-                this.logger.log("Setting error on enOnValidate: " + this.minAmount);
+                this.logger.log("Setting error on enOnValidate: " +
+                    (this.minAmountMessage || "Invalid Amount"));
+                // Defer so EN's own onValidate pass can't overwrite the error
                 window.setTimeout(() => {
                     ENGrid.setError(".en__field--withOther", this.minAmountMessage || "Invalid Amount");
-                });
+                }, 300);
             }
         }
         else if (this._amount.amount > this.maxAmount) {
@@ -53,11 +55,17 @@ export class MinMaxAmount {
             }
             this._form.validate = false;
             if (this.disableLiveValidation) {
-                this.logger.log("Setting error on enOnValidate: " + this.maxAmount);
+                this.logger.log("Setting error on enOnValidate: " +
+                    (this.maxAmountMessage || "Invalid Amount"));
+                // Defer so EN's own onValidate pass can't overwrite the error
                 window.setTimeout(() => {
                     ENGrid.setError(".en__field--withOther", this.maxAmountMessage || "Invalid Amount");
-                });
+                }, 300);
             }
+        }
+        else if (this.disableLiveValidation) {
+            // Amount is in range — clear any stale error left over from a previous submit
+            ENGrid.removeError(".en__field--withOther");
         }
         if (!this.disableLiveValidation) {
             window.setTimeout(this.liveValidate.bind(this), 300);

--- a/packages/scripts/dist/min-max-amount.js
+++ b/packages/scripts/dist/min-max-amount.js
@@ -10,6 +10,7 @@ export class MinMaxAmount {
         this.maxAmount = (_b = ENGrid.getOption("MaxAmount")) !== null && _b !== void 0 ? _b : 100000;
         this.minAmountMessage = ENGrid.getOption("MinAmountMessage");
         this.maxAmountMessage = ENGrid.getOption("MaxAmountMessage");
+        this.disableLiveValidation = ENGrid.getOption("DisableLiveValidation");
         this.enAmountValidator = null;
         this.logger = new EngridLogger("MinMaxAmount", "white", "purple", "🔢");
         if (!this.shouldRun()) {
@@ -17,8 +18,10 @@ export class MinMaxAmount {
             return;
         }
         this.setValidationConfigFromEN();
-        this._amount.onAmountChange.subscribe((s) => window.setTimeout(this.liveValidate.bind(this), 1000) // Wait 1 second for the amount to be updated
-        );
+        if (!this.disableLiveValidation) {
+            this._amount.onAmountChange.subscribe((s) => window.setTimeout(this.liveValidate.bind(this), 1000) // Wait 1 second for the amount to be updated
+            );
+        }
         this._form.onValidate.subscribe(this.enOnValidate.bind(this));
     }
     // Should we run the script?
@@ -36,6 +39,12 @@ export class MinMaxAmount {
                 otherAmount.focus();
             }
             this._form.validate = false;
+            if (this.disableLiveValidation) {
+                this.logger.log("Setting error on enOnValidate: " + this.minAmount);
+                window.setTimeout(() => {
+                    ENGrid.setError(".en__field--withOther", this.minAmountMessage || "Invalid Amount");
+                });
+            }
         }
         else if (this._amount.amount > this.maxAmount) {
             this.logger.log("Amount is greater than max amount: " + this.maxAmount);
@@ -43,11 +52,23 @@ export class MinMaxAmount {
                 otherAmount.focus();
             }
             this._form.validate = false;
+            if (this.disableLiveValidation) {
+                this.logger.log("Setting error on enOnValidate: " + this.maxAmount);
+                window.setTimeout(() => {
+                    ENGrid.setError(".en__field--withOther", this.maxAmountMessage || "Invalid Amount");
+                });
+            }
         }
-        window.setTimeout(this.liveValidate.bind(this), 300);
+        if (!this.disableLiveValidation) {
+            window.setTimeout(this.liveValidate.bind(this), 300);
+        }
     }
     // Disable Submit Button if the amount is not valid
     liveValidate() {
+        if (this.disableLiveValidation) {
+            this.logger.log("disableLiveValidation is set to true. Skipping live validation");
+            return;
+        }
         const amount = ENGrid.cleanAmount(this._amount.amount.toString());
         const activeElement = document.activeElement;
         if (activeElement &&

--- a/packages/scripts/src/interfaces/options.ts
+++ b/packages/scripts/src/interfaces/options.ts
@@ -16,6 +16,7 @@ export interface Options {
   MinAmountMessage?: string;
   MaxAmountMessage?: string;
   UseAmountValidatorFromEN?: boolean;
+  DisableLiveValidation?: boolean;
   SkipToMainContentLink?: boolean;
   SrcDefer?: boolean;
   SuppressPurchaseEcard?: boolean;

--- a/packages/scripts/src/min-max-amount.ts
+++ b/packages/scripts/src/min-max-amount.ts
@@ -22,6 +22,7 @@ export class MinMaxAmount {
   private maxAmount: number = ENGrid.getOption("MaxAmount") ?? 100000;
   private minAmountMessage = ENGrid.getOption("MinAmountMessage");
   private maxAmountMessage = ENGrid.getOption("MaxAmountMessage");
+  private disableLiveValidation = ENGrid.getOption("DisableLiveValidation");
   private enAmountValidator: Validator | null = null;
   private logger: EngridLogger = new EngridLogger(
     "MinMaxAmount",
@@ -35,9 +36,11 @@ export class MinMaxAmount {
       return;
     }
     this.setValidationConfigFromEN();
-    this._amount.onAmountChange.subscribe(
-      (s) => window.setTimeout(this.liveValidate.bind(this), 1000) // Wait 1 second for the amount to be updated
-    );
+    if (!this.disableLiveValidation) {
+      this._amount.onAmountChange.subscribe(
+        (s) => window.setTimeout(this.liveValidate.bind(this), 1000) // Wait 1 second for the amount to be updated
+      );
+    }
     this._form.onValidate.subscribe(this.enOnValidate.bind(this));
   }
   // Should we run the script?
@@ -57,18 +60,45 @@ export class MinMaxAmount {
         otherAmount.focus();
       }
       this._form.validate = false;
+
+      if (this.disableLiveValidation) {
+        this.logger.log("Setting error on enOnValidate: " + this.minAmount);
+        window.setTimeout(() => {
+          ENGrid.setError(
+            ".en__field--withOther",
+            this.minAmountMessage || "Invalid Amount"
+          );
+        });
+      }
     } else if (this._amount.amount > this.maxAmount) {
       this.logger.log("Amount is greater than max amount: " + this.maxAmount);
       if (otherAmount) {
         otherAmount.focus();
       }
       this._form.validate = false;
+
+      if (this.disableLiveValidation) {
+        this.logger.log("Setting error on enOnValidate: " + this.maxAmount);
+        window.setTimeout(() => {
+          ENGrid.setError(
+            ".en__field--withOther",
+            this.maxAmountMessage || "Invalid Amount"
+          );
+        });
+      }
     }
-    window.setTimeout(this.liveValidate.bind(this), 300);
+    if (!this.disableLiveValidation) {
+      window.setTimeout(this.liveValidate.bind(this), 300);
+    }
   }
 
   // Disable Submit Button if the amount is not valid
   liveValidate() {
+    if (this.disableLiveValidation) {
+      this.logger.log("disableLiveValidation is set to true. Skipping live validation");
+      return;
+    }
+
     const amount = ENGrid.cleanAmount(this._amount.amount.toString());
     const activeElement = document.activeElement as HTMLInputElement;
     if (

--- a/packages/scripts/src/min-max-amount.ts
+++ b/packages/scripts/src/min-max-amount.ts
@@ -62,13 +62,17 @@ export class MinMaxAmount {
       this._form.validate = false;
 
       if (this.disableLiveValidation) {
-        this.logger.log("Setting error on enOnValidate: " + this.minAmount);
+        this.logger.log(
+          "Setting error on enOnValidate: " +
+            (this.minAmountMessage || "Invalid Amount")
+        );
+        // Defer so EN's own onValidate pass can't overwrite the error
         window.setTimeout(() => {
           ENGrid.setError(
             ".en__field--withOther",
             this.minAmountMessage || "Invalid Amount"
           );
-        });
+        }, 300);
       }
     } else if (this._amount.amount > this.maxAmount) {
       this.logger.log("Amount is greater than max amount: " + this.maxAmount);
@@ -78,14 +82,21 @@ export class MinMaxAmount {
       this._form.validate = false;
 
       if (this.disableLiveValidation) {
-        this.logger.log("Setting error on enOnValidate: " + this.maxAmount);
+        this.logger.log(
+          "Setting error on enOnValidate: " +
+            (this.maxAmountMessage || "Invalid Amount")
+        );
+        // Defer so EN's own onValidate pass can't overwrite the error
         window.setTimeout(() => {
           ENGrid.setError(
             ".en__field--withOther",
             this.maxAmountMessage || "Invalid Amount"
           );
-        });
+        }, 300);
       }
+    } else if (this.disableLiveValidation) {
+      // Amount is in range — clear any stale error left over from a previous submit
+      ENGrid.removeError(".en__field--withOther");
     }
     if (!this.disableLiveValidation) {
       window.setTimeout(this.liveValidate.bind(this), 300);


### PR DESCRIPTION
This PR adds a new option to ENgrid: DisableLiveValidation.

With this optional prop, min-max-amount live validation can be skipped, and the error will show only when the user submits the donation.

**Backward Compatibility**
This addition is fully backward compatible. Clients that use MinMaxAmount and do not set the DisableLiveValidation prop will still experience live validation:

https://github.com/user-attachments/assets/1a3b1694-1c3a-4281-b6c4-86e2e446197c

**Usage Example**
On the SPCAI shopping cart project, live validation can now be disabled by setting DisableLiveValidation: true:

https://github.com/user-attachments/assets/814bf066-5dc4-47f3-ab25-61c0439b82fe