### PR TITLE
Fix regression from 0e7c53c1 that spawned RememberMe checked-state bug

### DIFF
--- a/packages/scripts/dist/remember-me.js
+++ b/packages/scripts/dist/remember-me.js
@@ -83,11 +83,9 @@ export class RememberMe {
             let hasFieldData = Object.keys(this.fieldData).length > 0;
             if (!hasFieldData) {
                 this.insertRememberMeOptin();
-                this.rememberMeOptIn = false;
             }
             else {
                 this.insertClearRememberMeLink();
-                this.rememberMeOptIn = true;
             }
             this.writeFields();
             this._form.onSubmit.subscribe(() => {

--- a/packages/scripts/src/remember-me.ts
+++ b/packages/scripts/src/remember-me.ts
@@ -134,10 +134,8 @@ export class RememberMe {
       let hasFieldData = Object.keys(this.fieldData).length > 0;
       if (!hasFieldData) {
         this.insertRememberMeOptin();
-        this.rememberMeOptIn = false;
       } else {
         this.insertClearRememberMeLink();
-        this.rememberMeOptIn = true;
       }
       this.writeFields();
       this._form.onSubmit.subscribe(() => {
@@ -452,9 +450,9 @@ export class RememberMe {
           } else if (this.fieldDonationAmountRadioName === this.fieldNames[i]) {
             field = document.querySelector(
               fieldSelector +
-                "[value='" +
-                this.fieldData[this.fieldNames[i]] +
-                "']"
+              "[value='" +
+              this.fieldData[this.fieldNames[i]] +
+              "']"
             ) as HTMLInputElement;
             if (field) {
               field.click();


### PR DESCRIPTION
Setting the "checked" state using RememberMe options was not respected when no Remote URL was present. This was fixed previously by MichaelT but that fix got undone and lost in a future commit.

Implemented: https://give.nationalgeographic.org/page/193147/subscribe/1?assets=opt-in-bugfix

Checked is default, no remote url, supporter data is saved on submission and autofilled on return