### PR TITLE
Update SwapAmounts to support Next Suggested Gift on a frequency basis

### DIFF
--- a/packages/scripts/dist/swap-amounts.d.ts
+++ b/packages/scripts/dist/swap-amounts.d.ts
@@ -32,13 +32,20 @@ export declare class SwapAmounts {
     private _frequency;
     private defaultChange;
     private swapped;
+    private hasOneTimeNSG;
+    private hasRecurringNSG;
     constructor();
     loadAmountsFromUrl(): void;
     swapAmounts(): void;
+    private shouldUseNSG;
     /**
      * Convert the internal config object into the structure Engaging Networks expects
      */
     private toEnAmountList;
+    /**
+     * Convert the Engaging Networks NSG config object into the structure Engaging Network Lists expect
+     */
+    private toEnAmountListNSG;
     shouldRun(): boolean;
     ignoreCurrentValue(): boolean;
 }

--- a/packages/scripts/dist/swap-amounts.js
+++ b/packages/scripts/dist/swap-amounts.js
@@ -38,7 +38,18 @@ export class SwapAmounts {
         this._frequency = DonationFrequency.getInstance();
         this.defaultChange = false; // Tracks if user changed away from default after swap
         this.swapped = false; // Tracks if we've already executed at least one swap
+        this.hasOneTimeNSG = false;
+        this.hasRecurringNSG = false;
         this.loadAmountsFromUrl();
+        this.hasOneTimeNSG = !!(window.EngagingNetworks.suggestedGift &&
+            window.EngagingNetworks.suggestedGift.single &&
+            window.EngagingNetworks.suggestedGift.single.length > 0);
+        this.hasRecurringNSG = !!(window.EngagingNetworks.suggestedGift &&
+            window.EngagingNetworks.suggestedGift.recurring &&
+            window.EngagingNetworks.suggestedGift.recurring.length > 0);
+        if (this.hasOneTimeNSG || this.hasRecurringNSG) {
+            this.logger.log("Detected NSG amounts", { suggestedGift: window.EngagingNetworks.suggestedGift });
+        }
         if (!this.shouldRun())
             return;
         // Respond when frequency changes
@@ -98,6 +109,13 @@ export class SwapAmounts {
         const config = configs[freq];
         if (!config)
             return;
+        if (this.shouldUseNSG(freq, config)) {
+            this.logger.log(`NSG present for ${freq}, using NSG amounts`, { suggestedGift: window.EngagingNetworks.suggestedGift });
+            window.EngagingNetworks.require._defined.enjs.swapList("donationAmt", this.toEnAmountListNSG(window.EngagingNetworks.suggestedGift, freq), { ignoreCurrentValue: true });
+            this._amount.load();
+            this.swapped = true;
+            return;
+        }
         const stickyDefault = !!config.stickyDefault;
         // If stickyDefault, always ignore current value so selected flag in list enforces default
         const ignoreCurrentValue = stickyDefault ? true : this.ignoreCurrentValue();
@@ -105,6 +123,15 @@ export class SwapAmounts {
         this._amount.load();
         this.logger.log("Amounts Swapped To", config, { ignoreCurrentValue });
         this.swapped = true;
+    }
+    shouldUseNSG(freq, config) {
+        if (freq === "onetime" && this.hasOneTimeNSG && !config.overrideNSG) {
+            return true;
+        }
+        if (freq === "monthly" && this.hasRecurringNSG && !config.overrideNSG) {
+            return true;
+        }
+        return false;
     }
     /**
      * Convert the internal config object into the structure Engaging Networks expects
@@ -116,13 +143,19 @@ export class SwapAmounts {
             value: value.toString(),
         }));
     }
+    /**
+     * Convert the Engaging Networks NSG config object into the structure Engaging Network Lists expect
+     */
+    toEnAmountListNSG(config, freq) {
+        const frequency = freq === "onetime" ? "single" : "recurring";
+        return config[frequency].map(({ nextSuggestedGift, value }) => ({
+            selected: nextSuggestedGift,
+            label: value > 0 ? value.toString() : "Other",
+            value: value > 0 ? value.toString() : "other",
+        }));
+    }
     shouldRun() {
-        const hasNSG = window.EngagingNetworks.suggestedGift !== undefined &&
-            Object.keys(window.EngagingNetworks.suggestedGift).length > 0;
-        if (!!window.EngridAmounts && hasNSG) {
-            this.logger.log("Not swapping amounts because NSG is active on page");
-        }
-        return !!window.EngridAmounts && !hasNSG;
+        return !!window.EngridAmounts;
     }
     ignoreCurrentValue() {
         const urlParam = ENGrid.getUrlParameter("transaction.donationAmt");

--- a/packages/scripts/src/swap-amounts.ts
+++ b/packages/scripts/src/swap-amounts.ts
@@ -43,6 +43,21 @@ interface FrequencyAmountsConfig {
    * the donor's currently selected amount and re-select the configured default.
    */
   stickyDefault?: boolean;
+  overrideNSG?: boolean; // When true, will not swap to NSG amounts even if NSG config present for the frequency
+}
+
+interface NextSuggestedGiftConfig {
+  currency: string;
+  single: {
+    nextSuggestedGift: boolean;
+    value: number,
+    id: number | string;
+  }[];
+  recurring: {
+    nextSuggestedGift: boolean;
+    value: number,
+    id: number | string;
+  }[];
 }
 
 export class SwapAmounts {
@@ -56,8 +71,23 @@ export class SwapAmounts {
   private _frequency: DonationFrequency = DonationFrequency.getInstance();
   private defaultChange = false; // Tracks if user changed away from default after swap
   private swapped = false; // Tracks if we've already executed at least one swap
+  private hasOneTimeNSG = false;
+  private hasRecurringNSG = false;
   constructor() {
     this.loadAmountsFromUrl();
+    this.hasOneTimeNSG = !!(
+      window.EngagingNetworks.suggestedGift &&
+      window.EngagingNetworks.suggestedGift.single &&
+      window.EngagingNetworks.suggestedGift.single.length > 0
+    );
+    this.hasRecurringNSG = !!(
+      window.EngagingNetworks.suggestedGift &&
+      window.EngagingNetworks.suggestedGift.recurring &&
+      window.EngagingNetworks.suggestedGift.recurring.length > 0
+    );
+    if (this.hasOneTimeNSG || this.hasRecurringNSG) {
+      this.logger.log("Detected NSG amounts", { suggestedGift: window.EngagingNetworks.suggestedGift });
+    }
     if (!this.shouldRun()) return;
 
     // Respond when frequency changes
@@ -118,6 +148,17 @@ export class SwapAmounts {
     const freq = this._frequency.frequency;
     const config = configs[freq];
     if (!config) return;
+    if (this.shouldUseNSG(freq, config)) {
+      this.logger.log(`NSG present for ${freq}, using NSG amounts`, { suggestedGift: window.EngagingNetworks.suggestedGift });
+      window.EngagingNetworks.require._defined.enjs.swapList(
+        "donationAmt",
+        this.toEnAmountListNSG(window.EngagingNetworks.suggestedGift, freq),
+        { ignoreCurrentValue: true }
+      );
+      this._amount.load();
+      this.swapped = true;
+      return;
+    }
     const stickyDefault = !!config.stickyDefault;
     // If stickyDefault, always ignore current value so selected flag in list enforces default
     const ignoreCurrentValue = stickyDefault ? true : this.ignoreCurrentValue();
@@ -131,6 +172,15 @@ export class SwapAmounts {
     this.logger.log("Amounts Swapped To", config, { ignoreCurrentValue });
     this.swapped = true;
   }
+  private shouldUseNSG(freq: string, config: FrequencyAmountsConfig) {
+    if (freq === "onetime" && this.hasOneTimeNSG && !config.overrideNSG) {
+      return true;
+    }
+    if (freq === "monthly" && this.hasRecurringNSG && !config.overrideNSG) {
+      return true;
+    }
+    return false;
+  }
   /**
    * Convert the internal config object into the structure Engaging Networks expects
    */
@@ -141,14 +191,19 @@ export class SwapAmounts {
       value: value.toString(),
     }));
   }
+  /**
+   * Convert the Engaging Networks NSG config object into the structure Engaging Network Lists expect
+   */
+  private toEnAmountListNSG(config: NextSuggestedGiftConfig, freq: string) {
+    const frequency = freq === "onetime" ? "single" : "recurring";
+    return config[frequency].map(({ nextSuggestedGift, value }) => ({
+      selected: nextSuggestedGift,
+      label: value > 0 ? value.toString() : "Other",
+      value: value > 0 ? value.toString() : "other",
+    }));
+  }
   shouldRun() {
-    const hasNSG =
-      window.EngagingNetworks.suggestedGift !== undefined &&
-      Object.keys(window.EngagingNetworks.suggestedGift).length > 0;
-    if (!!window.EngridAmounts && hasNSG) {
-      this.logger.log("Not swapping amounts because NSG is active on page");
-    }
-    return !!window.EngridAmounts && !hasNSG;
+    return !!window.EngridAmounts;
   }
   ignoreCurrentValue() {
     const urlParam = ENGrid.getUrlParameter("transaction.donationAmt");


### PR DESCRIPTION
# Updates to the swap-amounts component

* Checks if the page has a NSG for onetime and monthly frequencies
* Adds config `overrideNSG` to be set for each frequency
* If one-time NSG is available, do not swap list for one-time amounts unless `config.onetime.overrideNSG` is true
* If monthly NSG is available, do not swap list for monthly amounts unless `config.monthly.overrideNSG` is true
* Swapping between a NSG list and a EngridAmounts list retains their respective values (ie. if NSG has values for onetime, it will use those values when swapping back from monthly to onetime)


Allows for swap-amounts to still function on monthly for swapping if NSG only suggests amounts for one-time, or vice-versa. Previously, if NSG was detected at all, swap-amounts would not run.


## Test pages
**NSG for monthly and one-time flow:** https://act.amnestyusa.org/page/193997/data/1?mode=DEMO
**NSG for one-time only flow:** https://act.amnestyusa.org/page/194210/data/1?mode=DEMO

**Edit page for monthly and one-time:** https://ca.engagingnetworks.app/index.html#pages/194211/edit
**Edit page for one-time only:** https://ca.engagingnetworks.app/index.html#pages/194211/edit

### One-time only flow:
1. Enter the email of a supporter that has a NSG staged (omitted from this publicly viewable PR)
2. Submit the form, donation page opens with data autofilled
3. Swapping from One-Time to Monthly should display the amounts set in `window.EngridAmounts.monthly.amounts`
4. Swapping back to One-Time should display the amounts set in `window.EngagingNetworks.suggestedGift.single` and have the sticky-default of the entry with nextSuggestedGift = true
### Monthly and one-time flow:
1. Enter the email of a supporter that has a NSG staged (omitted from this publicly viewable PR)
2. Submit the form, donation page opens with data autofilled
3. Swapping from One-Time to Monthly should display the amounts set in `window.EngagingNetworks.suggestedGift.recurring` and have the sticky-default of the entry with nextSuggestedGift = true
4. Swapping back to One-Time should display the amounts set in `window.EngagingNetworks.suggestedGift.single` and have the sticky-default of the entry with nextSuggestedGift = true
### Update "Amount Swap" codeblock for both edit page links (client: AIUSA)
1. In the "onetime" config area, set overrideNSG: true
2. Re-test one time and monthy and one-time flows, noting that the one-time amounts are those set in the EngridAmounts config, and not the NSG values.