### PR TITLE
Core: Trigger watchForError callbacks from setError

### DIFF
--- a/packages/scripts/dist/engrid.d.ts
+++ b/packages/scripts/dist/engrid.d.ts
@@ -54,6 +54,7 @@ export declare abstract class ENGrid {
     static removeHtml(target: string): void;
     static slugify(text: string): string;
     static watchForError(callback: Function): void;
+    private static getErrorCallbackKey;
     static getPaymentType(): string;
     static setPaymentType(paymentType: string): void;
     static isInViewport(element: HTMLElement): boolean;

--- a/packages/scripts/dist/engrid.js
+++ b/packages/scripts/dist/engrid.js
@@ -1,3 +1,4 @@
+const errorCallbacks = new Map();
 export class ENGrid {
     constructor() {
         if (!ENGrid.enForm) {
@@ -426,6 +427,7 @@ export class ENGrid {
             else {
                 errorMessageElement.innerHTML = errorMessage;
             }
+            errorCallbacks.forEach((callback) => callback());
         }
     }
     static removeError(element) {
@@ -510,6 +512,24 @@ export class ENGrid {
     // This function is used to run a callback function when an error is displayed on the page
     static watchForError(callback) {
         const errorElement = document.querySelector(".en__errorList");
+        const callbackType = ENGrid.getErrorCallbackKey(callback);
+        // Register callback so setError can trigger it too
+        if (!errorCallbacks.has(callbackType)) {
+            errorCallbacks.set(callbackType, callback);
+        }
+        if (errorElement && !errorElement.dataset[callbackType]) {
+            errorElement.dataset[callbackType] = "true";
+            const observer = new MutationObserver(function (mutations) {
+                mutations.forEach(function (mutation) {
+                    if (mutation.type === "childList" && mutation.addedNodes.length > 0) {
+                        callback();
+                    }
+                });
+            });
+            observer.observe(errorElement, { childList: true });
+        }
+    }
+    static getErrorCallbackKey(callback) {
         const capitalize = (word) => word.charAt(0).toUpperCase() + word.slice(1);
         // Avoid duplicate callbacks
         let callbackType = callback.toString();
@@ -523,18 +543,7 @@ export class ENGrid {
         callbackType = callbackType.replace(/[^a-zA-Z0-9]/g, "");
         // Limit to 20 characters and add prefix
         callbackType = callbackType.substring(0, 20);
-        callbackType = "engrid" + capitalize(callbackType);
-        if (errorElement && !errorElement.dataset[callbackType]) {
-            errorElement.dataset[callbackType] = "true";
-            const observer = new MutationObserver(function (mutations) {
-                mutations.forEach(function (mutation) {
-                    if (mutation.type === "childList" && mutation.addedNodes.length > 0) {
-                        callback();
-                    }
-                });
-            });
-            observer.observe(errorElement, { childList: true });
-        }
+        return "engrid" + capitalize(callbackType);
     }
     // Get the Payment Type
     static getPaymentType() {

--- a/packages/scripts/src/engrid.ts
+++ b/packages/scripts/src/engrid.ts
@@ -1,5 +1,7 @@
 import { Options } from ".";
 
+const errorCallbacks = new Map<string, Function>();
+
 export abstract class ENGrid {
   constructor() {
     if (!ENGrid.enForm) {
@@ -492,6 +494,7 @@ export abstract class ENGrid {
       } else {
         errorMessageElement.innerHTML = errorMessage;
       }
+      errorCallbacks.forEach((callback) => callback());
     }
   }
   static removeError(element: string | HTMLElement) {
@@ -592,21 +595,13 @@ export abstract class ENGrid {
     const errorElement = document.querySelector(
       ".en__errorList"
     ) as HTMLUListElement;
-    const capitalize = (word: string) =>
-      word.charAt(0).toUpperCase() + word.slice(1);
-    // Avoid duplicate callbacks
-    let callbackType = callback.toString();
-    if (callbackType.indexOf("function") === 0) {
-      callbackType = callbackType.replace("function ", "");
+    const callbackType = ENGrid.getErrorCallbackKey(callback);
+
+    // Register callback so setError can trigger it too
+    if (!errorCallbacks.has(callbackType)) {
+      errorCallbacks.set(callbackType, callback);
     }
-    if (callbackType.indexOf("(") > 0) {
-      callbackType = callbackType.substring(0, callbackType.indexOf("("));
-    }
-    // Remove invalid characters
-    callbackType = callbackType.replace(/[^a-zA-Z0-9]/g, "");
-    // Limit to 20 characters and add prefix
-    callbackType = callbackType.substring(0, 20);
-    callbackType = "engrid" + capitalize(callbackType);
+
     if (errorElement && !errorElement.dataset[callbackType]) {
       errorElement.dataset[callbackType] = "true";
 
@@ -619,6 +614,25 @@ export abstract class ENGrid {
       });
       observer.observe(errorElement, { childList: true });
     }
+  }
+
+  private static getErrorCallbackKey(callback: Function): string {
+    const capitalize = (word: string) =>
+      word.charAt(0).toUpperCase() + word.slice(1);
+
+    // Avoid duplicate callbacks
+    let callbackType = callback.toString();
+    if (callbackType.indexOf("function") === 0) {
+      callbackType = callbackType.replace("function ", "");
+    }
+    if (callbackType.indexOf("(") > 0) {
+      callbackType = callbackType.substring(0, callbackType.indexOf("("));
+    }
+    // Remove invalid characters
+    callbackType = callbackType.replace(/[^a-zA-Z0-9]/g, "");
+    // Limit to 20 characters and add prefix
+    callbackType = callbackType.substring(0, 20);
+    return "engrid" + capitalize(callbackType);
   }
   // Get the Payment Type
   static getPaymentType(): string {


### PR DESCRIPTION
# Design: Trigger watchForError callbacks from setError

## Problem
`ENGrid.watchForError()` observes `.en__errorList` for added children, but `ENGrid.setError()` adds `.en__field__error` directly to a field wrapper. As a result, callbacks registered through `watchForError` do not run when `setError` displays a field-level error.

## Goal
Make `setError` trigger all callbacks registered with `watchForError`, without breaking backward compatibility.

## Constraints
- Keep existing public signatures: `setError(element, errorMessage)` and `watchForError(callback)`.
- Preserve the deduplication behavior already in `watchForError` (callback key derived from `callback.toString()`).
- The only current consumers are `ENGrid.enableSubmit` and `iFrame.sendIframeHeight`; both are idempotent.

## Approach: Shared Callback Registry
Add a module-level `Map<string, Function>` to `packages/scripts/src/engrid.ts`. `watchForError` registers the callback in the map and also attaches the existing `.en__errorList` MutationObserver. `setError` iterates the map and invokes each registered callback after injecting the field-level error.

## Changes
- `packages/scripts/src/engrid.ts`
  - Add `const errorCallbacks = new Map<string, Function>();` at module scope.
  - Refactor the `callbackType` derivation into a private helper so both `watchForError` and `setError` can use it.
  - In `watchForError`, register the callback in the map before attaching the observer.
  - In `setError`, after adding/updating `.en__field__error`, invoke every callback in the map.

## Backward Compatibility
- Signatures unchanged.
- Callbacks now fire for field-level errors created by `setError`. This is the intended behavior change.
- Existing deduplication keying is preserved.