### PR TITLE
Fix thank-you conditional content selectors

### DIFF
--- a/packages/scripts/dist/show-hide-radio-checkboxes.js
+++ b/packages/scripts/dist/show-hide-radio-checkboxes.js
@@ -127,7 +127,7 @@ export class ShowHideRadioCheckboxes {
                 state.push({
                     page: ENGrid.getPageID(),
                     class: this.classes,
-                    value: element.value,
+                    value: element.value.replace(/\W/g, ""),
                 });
                 this.logger.log("storing radio state", state[state.length - 1]);
             }
@@ -142,7 +142,7 @@ export class ShowHideRadioCheckboxes {
                 state.push({
                     page: ENGrid.getPageID(),
                     class: this.classes,
-                    value: (_b = (_a = [...this.elements].find((el) => el.checked)) === null || _a === void 0 ? void 0 : _a.value) !== null && _b !== void 0 ? _b : "N", // First checked value or "N" if none
+                    value: (_b = (_a = [...this.elements].find((el) => el.checked)) === null || _a === void 0 ? void 0 : _a.value.replace(/\W/g, "")) !== null && _b !== void 0 ? _b : "N", // First checked value or "N" if none
                 });
                 this.logger.log("storing checkbox state", state[state.length - 1]);
             }

--- a/packages/scripts/dist/thank-you-page-conditional-content.js
+++ b/packages/scripts/dist/thank-you-page-conditional-content.js
@@ -22,13 +22,16 @@ export class ThankYouPageConditionalContent {
             state.forEach((item) => {
                 this.logger.log("Processing TY page conditional content item:", item);
                 if (ENGrid.getPageID() === item.page) {
+                    const inputValue = item.value.replace(/\W/g, "");
+                    const classPrefix = CSS.escape(item.class);
+                    const selectedClass = CSS.escape(`${item.class}${inputValue}`);
                     document
-                        .querySelectorAll(`[class*="${item.class}"]`)
+                        .querySelectorAll(`[class*="${classPrefix}"]`)
                         .forEach((el) => {
                         el.classList.add("hide");
                     });
                     document
-                        .querySelectorAll(`.${item.class}${item.value}`)
+                        .querySelectorAll(`.${selectedClass}`)
                         .forEach((el) => {
                         el.classList.remove("hide");
                     });

--- a/packages/scripts/src/show-hide-radio-checkboxes.ts
+++ b/packages/scripts/src/show-hide-radio-checkboxes.ts
@@ -150,7 +150,7 @@ export class ShowHideRadioCheckboxes {
         state.push({
           page: ENGrid.getPageID(),
           class: this.classes,
-          value: element.value,
+          value: element.value.replace(/\W/g, ""),
         });
 
         this.logger.log("storing radio state", state[state.length - 1]);
@@ -173,7 +173,7 @@ export class ShowHideRadioCheckboxes {
           value:
             [...this.elements].find(
               (el): el is HTMLInputElement => (el as HTMLInputElement).checked
-            )?.value ?? "N", // First checked value or "N" if none
+            )?.value.replace(/\W/g, "") ?? "N", // First checked value or "N" if none
         });
 
         this.logger.log("storing checkbox state", state[state.length - 1]);

--- a/packages/scripts/src/thank-you-page-conditional-content.ts
+++ b/packages/scripts/src/thank-you-page-conditional-content.ts
@@ -36,13 +36,17 @@ export class ThankYouPageConditionalContent {
         this.logger.log("Processing TY page conditional content item:", item);
 
         if (ENGrid.getPageID() === item.page) {
+          const inputValue = item.value.replace(/\W/g, "");
+          const classPrefix = CSS.escape(item.class);
+          const selectedClass = CSS.escape(`${item.class}${inputValue}`);
+
           document
-            .querySelectorAll(`[class*="${item.class}"]`)
+            .querySelectorAll(`[class*="${classPrefix}"]`)
             .forEach((el) => {
               el.classList.add("hide");
             });
           document
-            .querySelectorAll(`.${item.class}${item.value}`)
+            .querySelectorAll(`.${selectedClass}`)
             .forEach((el) => {
               el.classList.remove("hide");
             });


### PR DESCRIPTION
## Summary
- normalize stored radio and checkbox values to match conditional-content class suffixes
- normalize existing session values when applying thank-you-page conditional content
- escape dynamic CSS selector components before querying the DOM
- regenerate the scripts package distribution files

## Validation
- TypeScript check with --noEmit
- npm run build in packages/scripts
- git diff --check

## Example
A supporter question value such as My shipping address is the same as my billing address. now targets engrid__supporterquestions2479687-Myshippingaddressisthesameasmybillingaddress instead of constructing an invalid selector containing spaces and punctuation.